### PR TITLE
MRELEASE-699 release:update-versions should support -DreleaseVersion too 

### DIFF
--- a/maven-release-manager/src/main/components-fragment.xml
+++ b/maven-release-manager/src/main/components-fragment.xml
@@ -84,6 +84,7 @@
         <updateVersionsPhases>
           <phase>check-poms</phase>
           <phase>create-backup-poms</phase>
+          <phase>map-release-versions</phase>
           <phase>map-development-versions</phase>
           <phase>rewrite-pom-versions</phase>
         </updateVersionsPhases>

--- a/maven-release-manager/src/main/java/org/apache/maven/shared/release/phase/RewritePomVersionsPhase.java
+++ b/maven-release-manager/src/main/java/org/apache/maven/shared/release/phase/RewritePomVersionsPhase.java
@@ -50,12 +50,16 @@ public class RewritePomVersionsPhase
     protected Map getOriginalVersionMap( ReleaseDescriptor releaseDescriptor, List<MavenProject> reactorProjects,
                                          boolean simulate )
     {
-        return releaseDescriptor.getReleaseVersions();
+        return releaseDescriptor.getOriginalVersions( reactorProjects );
     }
 
     protected Map getNextVersionMap( ReleaseDescriptor releaseDescriptor )
     {
-        return releaseDescriptor.getDevelopmentVersions();
+        if (releaseDescriptor.getDefaultReleaseVersion() != null) {
+            return releaseDescriptor.getReleaseVersions();
+        } else {
+            return releaseDescriptor.getDevelopmentVersions();
+        }
     }
 
     protected String getResolvedSnapshotVersion( String artifactVersionlessKey, Map resolvedSnapshotsMap )

--- a/maven-release-plugin/src/main/java/org/apache/maven/plugins/release/UpdateVersionsMojo.java
+++ b/maven-release-plugin/src/main/java/org/apache/maven/plugins/release/UpdateVersionsMojo.java
@@ -72,6 +72,14 @@ public class UpdateVersionsMojo
     private String developmentVersion;
 
     /**
+     * Default version to use when preparing a release or a branch.
+     *
+     * @parameter expression="${releaseVersion}"
+     * @since 2.0-beta-8
+     */
+    private String releaseVersion;
+
+    /**
      * @parameter expression="${session}"
      * @readonly
      * @required
@@ -91,6 +99,7 @@ public class UpdateVersionsMojo
         config.setAddSchema( addSchema );
         config.setAutoVersionSubmodules( autoVersionSubmodules );
         config.setDefaultDevelopmentVersion( developmentVersion );
+        config.setDefaultReleaseVersion( releaseVersion );
 
         Map originalScmInfo = new HashMap();
         originalScmInfo.put( ArtifactUtils.versionlessKey( project.getGroupId(), project.getArtifactId() ), project.getScm() );


### PR DESCRIPTION
MRELEASE-699 release:update-versions should support -DreleaseVersion too (not only -DdevelopmentVersion), so it also supports not suffixing the version with -SNAPSHOT

http://jira.codehaus.org/browse/MRELEASE-699