### PR TITLE
MRELEASE-834 release:prepare fails when a system property starting with dependency is given

### DIFF
--- a/maven-release-manager/src/main/java/org/apache/maven/shared/release/config/ReleaseUtils.java
+++ b/maven-release-manager/src/main/java/org/apache/maven/shared/release/config/ReleaseUtils.java
@@ -253,6 +253,13 @@ public class ReleaseUtils
                     versionType = ReleaseDescriptor.RELEASE_KEY;
                 }
 
+                // system property which is *not* a dependency, see
+                // http://jira.codehaus.org/browse/MRELEASE-834
+                if ( endIndex == -1 )
+                {
+                    continue;
+                }
+
                 artifactVersionlessKey = propertyName.substring( startIndex, endIndex );
 
                 if ( resolvedDependencies.containsKey( artifactVersionlessKey ) )

--- a/maven-release-manager/src/test/java/org/apache/maven/shared/release/config/ReleaseUtilsTest.java
+++ b/maven-release-manager/src/test/java/org/apache/maven/shared/release/config/ReleaseUtilsTest.java
@@ -284,6 +284,14 @@ public class ReleaseUtilsTest
         assertEquals( "1.3-SNAPSHOT", versionMap.get( ReleaseDescriptor.DEVELOPMENT_KEY) );
     }
 
+    // MRELEASE-834
+    public void testSystemPropertyStartingWithDependency() throws IOException
+    {
+        Properties properties = new Properties();
+        properties.setProperty("dependency.locations.enabled", "false");
+        ReleaseDescriptor releaseDescriptor = ReleaseUtils.copyPropertiesToReleaseDescriptor(properties);
+    }
+
     private static ReleaseDescriptor copyReleaseDescriptor( ReleaseDescriptor originalReleaseDescriptor )
     {
         return createReleaseDescriptor( originalReleaseDescriptor.getWorkingDirectory() );

--- a/maven-release-manager/src/test/java/org/apache/maven/shared/release/config/ReleaseUtilsTest.java
+++ b/maven-release-manager/src/test/java/org/apache/maven/shared/release/config/ReleaseUtilsTest.java
@@ -285,11 +285,19 @@ public class ReleaseUtilsTest
     }
 
     // MRELEASE-834
-    public void testSystemPropertyStartingWithDependency() throws IOException
+    public void testSystemPropertyStartingWithDependency()
+        throws IOException
     {
         Properties properties = new Properties();
-        properties.setProperty("dependency.locations.enabled", "false");
-        ReleaseDescriptor releaseDescriptor = ReleaseUtils.copyPropertiesToReleaseDescriptor(properties);
+        properties.setProperty( "dependency.locations.enabled", "false" );
+        String relDependencyKey = ArtifactUtils.versionlessKey( "com.release.magic", "dependency" );
+        properties.put( "dependency." + relDependencyKey  + ".release", "1.3" );
+
+        ReleaseDescriptor descriptor = ReleaseUtils.copyPropertiesToReleaseDescriptor( properties );
+
+        Map<String, String> versionMap = (Map<String, String>) descriptor.getResolvedSnapshotDependencies().get( relDependencyKey );
+        assertEquals( "1.3", versionMap.get( ReleaseDescriptor.RELEASE_KEY ) );
+
     }
 
     private static ReleaseDescriptor copyReleaseDescriptor( ReleaseDescriptor originalReleaseDescriptor )


### PR DESCRIPTION
http://jira.codehaus.org/browse/MRELEASE-834