### PR TITLE
[MRELEASE-896] Deprecate and disable useReleaseProfile

### DIFF
--- a/maven-release-plugin/src/main/java/org/apache/maven/plugins/release/PerformReleaseMojo.java
+++ b/maven-release-plugin/src/main/java/org/apache/maven/plugins/release/PerformReleaseMojo.java
@@ -101,8 +101,11 @@ public class PerformReleaseMojo
      * Whether to use the release profile that adds sources and javadocs to the released artifact, if appropriate.
      * If set to true, the release plugin sets the property "performRelease" to true, which activates the profile
      * "release-profile", which is inherited from the super pom.
+     * 
+     * @deprecated The release profile will be removed from future versions of the super POM
      */
-    @Parameter( defaultValue = "true", property = "useReleaseProfile" )
+    @Parameter( defaultValue = "false", property = "useReleaseProfile" )
+    @Deprecated
     private boolean useReleaseProfile;
 
     /**


### PR DESCRIPTION
There are some indications [1, 2] that the release-profile will disappear from Maven's super POM somewhen in the future. There was also an attempt back in 2009 to remove it but it was re-added again [3].
In order to support the removal of this profile, I suggest to disable its default activation in the maven-release-plugin. Additionally, I suggest to deprecate the useReleaseProfile parameter in the PerformReleaseMojo.

[1] https://github.com/apache/maven/blob/master/maven-model-builder/src/main/resources/org/apache/maven/model/pom-4.0.0.xml#L100
[2] http://mail-archives.apache.org/mod_mbox/maven-dev/201411.mbox/%3c20141128002840.32FCB4340A7F@dd34514.kasserver.com%3e
[3] https://github.com/apache/maven/commit/3870ab0e6021eb17d04883f97fe144d2db96e745