### PR TITLE
Fix for MRELEASE-975

### DIFF
--- a/maven-release-manager/src/main/java/org/apache/maven/shared/release/phase/MapVersionsPhase.java
+++ b/maven-release-manager/src/main/java/org/apache/maven/shared/release/phase/MapVersionsPhase.java
@@ -323,6 +323,11 @@ public class MapVersionsPhase
         VersionPolicy policy = versionPolicies.get( policyId );
         VersionPolicyRequest request = new VersionPolicyRequest().setVersion( baseVersion );
 
+        if ( policy == null )
+        {
+            throw new PolicyException( "Policy '" + policyId + "' is unknown, available: " + versionPolicies.keySet() );
+        }
+
         return convertToSnapshot ? policy.getDevelopmentVersion( request ).getVersion()
                         : policy.getReleaseVersion( request ).getVersion();
     }


### PR DESCRIPTION
fixes https://issues.apache.org/jira/browse/MRELEASE-975

When passing in an unknown project version policy id with 
-DprojectVersionPolicyId, the plugin will throw an NPE.