### PR TITLE
[MRELEASE-977] makes the release:branch goal ask for branch name if not given

### DIFF
--- a/maven-release-manager/src/main/components-fragment.xml
+++ b/maven-release-manager/src/main/components-fragment.xml
@@ -70,6 +70,7 @@
           <phase>scm-check-modifications</phase>
           <phase>create-backup-poms</phase>
           <phase>map-branch-versions</phase>
+          <phase>branch-input-variables</phase>
           <phase>map-development-versions</phase>
           <phase>rewrite-poms-for-branch</phase>
           <phase>scm-commit-branch</phase>
@@ -217,6 +218,40 @@
         <snapshotsRequired>false</snapshotsRequired>
       </configuration>
       <requirements>
+        <requirement>
+          <role>org.apache.maven.shared.release.scm.ScmRepositoryConfigurator</role>
+        </requirement>
+      </requirements>
+    </component>
+    <component>
+      <role>org.apache.maven.shared.release.phase.ReleasePhase</role>
+      <role-hint>input-variables</role-hint>
+      <implementation>org.apache.maven.shared.release.phase.InputVariablesPhase</implementation>
+      <configuration>
+        <branchOperation>false</branchOperation>
+      </configuration>
+      <requirements>
+        <requirement>
+          <role>org.codehaus.plexus.components.interactivity.Prompter</role>
+          <role-hint>default</role-hint>
+        </requirement>
+        <requirement>
+          <role>org.apache.maven.shared.release.scm.ScmRepositoryConfigurator</role>
+        </requirement>
+      </requirements>
+    </component>
+    <component>
+      <role>org.apache.maven.shared.release.phase.ReleasePhase</role>
+      <role-hint>branch-input-variables</role-hint>
+      <implementation>org.apache.maven.shared.release.phase.InputVariablesPhase</implementation>
+      <configuration>
+        <branchOperation>true</branchOperation>
+      </configuration>
+      <requirements>
+        <requirement>
+          <role>org.codehaus.plexus.components.interactivity.Prompter</role>
+          <role-hint>default</role-hint>
+        </requirement>
         <requirement>
           <role>org.apache.maven.shared.release.scm.ScmRepositoryConfigurator</role>
         </requirement>

--- a/maven-release-manager/src/main/java/org/apache/maven/shared/release/phase/InputVariablesPhase.java
+++ b/maven-release-manager/src/main/java/org/apache/maven/shared/release/phase/InputVariablesPhase.java
@@ -32,7 +32,6 @@ import org.apache.maven.shared.release.env.ReleaseEnvironment;
 import org.apache.maven.shared.release.scm.ReleaseScmRepositoryException;
 import org.apache.maven.shared.release.scm.ScmRepositoryConfigurator;
 import org.apache.maven.shared.release.util.ReleaseUtil;
-import org.codehaus.plexus.component.annotations.Component;
 import org.codehaus.plexus.component.annotations.Requirement;
 import org.codehaus.plexus.components.interactivity.Prompter;
 import org.codehaus.plexus.components.interactivity.PrompterException;
@@ -51,7 +50,6 @@ import java.util.Properties;
  *
  * @author <a href="mailto:brett@apache.org">Brett Porter</a>
  */
-@Component( role = ReleasePhase.class, hint = "input-variables" )
 public class InputVariablesPhase
     extends AbstractReleasePhase
 {
@@ -62,6 +60,11 @@ public class InputVariablesPhase
     private Prompter prompter;
 
     /**
+     * Whether this is a branch or a tag operation.
+     */
+    private boolean branchOperation;
+
+    /**
      * Tool that gets a configured SCM repository from release configuration.
      */
     @Requirement
@@ -70,6 +73,11 @@ public class InputVariablesPhase
     void setPrompter( Prompter prompter )
     {
         this.prompter = prompter;
+    }
+
+    boolean isBranchOperation()
+    {
+        return branchOperation;
     }
 
     protected ScmProvider getScmProvider( ReleaseDescriptor releaseDescriptor, ReleaseEnvironment releaseEnvironment )
@@ -159,19 +167,47 @@ public class InputVariablesPhase
             {
                 try
                 {
-                    tag =
-                        prompter.prompt( "What is SCM release tag or label for \"" + project.getName() + "\"? ("
-                            + project.getGroupId() + ":" + project.getArtifactId() + ")", defaultTag );
+                    if ( branchOperation )
+                    {
+                        tag =
+                            prompter.prompt( "What is the branch name for \"" + project.getName() + "\"? ("
+                                             + project.getGroupId() + ":" + project.getArtifactId() + ")" );
+                    }
+                    else
+                    {
+                        tag =
+                            prompter.prompt( "What is the SCM release tag or label for \"" + project.getName() + "\"? ("
+                                             + project.getGroupId() + ":" + project.getArtifactId() + ")", defaultTag );
+                    }
                 }
                 catch ( PrompterException e )
                 {
                     throw new ReleaseExecutionException( "Error reading version from input handler: " + e.getMessage(),
                                                          e );
                 }
+
+                if ( tag == null || tag.trim().isEmpty() )
+                {
+                    if ( branchOperation )
+                    {
+                        throw new ReleaseExecutionException( "No branch name was given." );
+                    }
+                    else
+                    {
+                        throw new ReleaseExecutionException( "No tag name was given." );
+                    }
+                }
             }
             else
             {
-                tag = defaultTag;
+                if ( branchOperation && tag == null )
+                {
+                    throw new ReleaseExecutionException( "No branch name was given." );
+                }
+                else
+                {
+                    tag = defaultTag;
+                }
             }
             releaseDescriptor.setScmReleaseLabel( tag );
         }

--- a/maven-release-manager/src/test/java/org/apache/maven/shared/release/phase/BranchInputVariablesPhaseTest.java
+++ b/maven-release-manager/src/test/java/org/apache/maven/shared/release/phase/BranchInputVariablesPhaseTest.java
@@ -20,7 +20,6 @@ package org.apache.maven.shared.release.phase;
  */
 
 import static org.junit.Assert.*;
-import static org.mockito.Matchers.eq;
 import static org.mockito.Matchers.isA;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
@@ -46,7 +45,7 @@ import org.junit.Test;
  *
  * @author <a href="mailto:brett@apache.org">Brett Porter</a>
  */
-public class InputVariablesPhaseTest
+public class BranchInputVariablesPhaseTest
     extends PlexusJUnit4TestCase
 {
     private InputVariablesPhase phase;
@@ -55,7 +54,7 @@ public class InputVariablesPhaseTest
         throws Exception
     {
         super.setUp();
-        phase = (InputVariablesPhase) lookup( ReleasePhase.ROLE, "input-variables" );
+        phase = (InputVariablesPhase) lookup( ReleasePhase.ROLE, "branch-input-variables" );
     }
 
     @Test
@@ -64,7 +63,7 @@ public class InputVariablesPhaseTest
     {
         // prepare
         Prompter mockPrompter = mock( Prompter.class );
-        when( mockPrompter.prompt( isA( String.class ), eq( "artifactId-1.0" ) ) ).thenReturn( "tag-value",
+        when( mockPrompter.prompt( isA( String.class ) ) ).thenReturn( "tag-value",
                                                                                                "simulated-tag-value" );
         phase.setPrompter( mockPrompter );
 
@@ -91,7 +90,7 @@ public class InputVariablesPhaseTest
         // verify
         assertEquals( "Check tag", "simulated-tag-value", releaseDescriptor.getScmReleaseLabel() );
 
-        verify( mockPrompter, times( 2 ) ).prompt( isA( String.class ), eq( "artifactId-1.0" ) );
+        verify( mockPrompter, times( 2 ) ).prompt( isA( String.class ) );
         verifyNoMoreInteractions( mockPrompter );
     }
 
@@ -126,43 +125,6 @@ public class InputVariablesPhaseTest
         {
             assertNull( "check no cause", e.getCause() );
         }
-    }
-
-    @Test
-    public void testInputVariablesNonInteractive()
-        throws Exception
-    {
-        // prepare
-        Prompter mockPrompter = mock( Prompter.class );
-        phase.setPrompter( mockPrompter );
-
-        List<MavenProject> reactorProjects = Collections.singletonList( createProject( "artifactId", "1.0" ) );
-
-        ReleaseDescriptor releaseDescriptor = new ReleaseDescriptor();
-        releaseDescriptor.setInteractive( false );
-        releaseDescriptor.mapReleaseVersion( "groupId:artifactId", "1.0" );
-        releaseDescriptor.setScmSourceUrl( "scm:svn:file://localhost/tmp/scm-repo" );
-
-        // execute
-        phase.execute( releaseDescriptor, new DefaultReleaseEnvironment(), reactorProjects );
-
-        // verify
-        assertEquals( "Check tag", "artifactId-1.0", releaseDescriptor.getScmReleaseLabel() );
-
-        // prepare
-        releaseDescriptor = new ReleaseDescriptor();
-        releaseDescriptor.setInteractive( false );
-        releaseDescriptor.mapReleaseVersion( "groupId:artifactId", "1.0" );
-        releaseDescriptor.setScmSourceUrl( "scm:svn:file://localhost/tmp/scm-repo" );
-
-        // execute
-        phase.simulate( releaseDescriptor, new DefaultReleaseEnvironment(), reactorProjects );
-
-        // verify
-        assertEquals( "Check tag", "artifactId-1.0", releaseDescriptor.getScmReleaseLabel() );
-
-        // never use prompter
-        verifyNoMoreInteractions( mockPrompter );
     }
 
     @Test
@@ -258,7 +220,7 @@ public class InputVariablesPhaseTest
         }
         catch ( ReleaseExecutionException e )
         {
-            assertEquals( "check cause", PrompterException.class, e.getCause().getClass() );
+            assertEquals( "No branch name was given.", e.getMessage() );
         }
 
         // prepare
@@ -275,95 +237,71 @@ public class InputVariablesPhaseTest
         }
         catch ( ReleaseExecutionException e )
         {
-            assertEquals( "check cause", PrompterException.class, e.getCause().getClass() );
+            assertEquals( "No branch name was given.", e.getMessage() );
         }
 
         // verify
-        verify( mockPrompter, times( 2 ) ).prompt( isA( String.class ), isA( String.class ) );
+        verify( mockPrompter, times( 2 ) ).prompt( isA( String.class ) );
         verifyNoMoreInteractions( mockPrompter );
     }
 
-    // MRELEASE-110
-    @Test
-    public void testCvsTag()
-        throws Exception
-    {
-        // prepare
-        Prompter mockPrompter = mock( Prompter.class );
-        phase.setPrompter( mockPrompter );
-
-        List<MavenProject> reactorProjects = Collections.singletonList( createProject( "artifactId", "1.0" ) );
-
-        ReleaseDescriptor releaseConfiguration = new ReleaseDescriptor();
-        releaseConfiguration.setInteractive( false );
-        releaseConfiguration.mapReleaseVersion( "groupId:artifactId", "1.0" );
-        releaseConfiguration.setScmSourceUrl( "scm:cvs:pserver:anoncvs@localhost:/tmp/scm-repo:module" );
-
-        // execute
-        phase.execute( releaseConfiguration, new DefaultReleaseEnvironment(), reactorProjects );
-
-        // verify
-        assertEquals( "Check tag", "artifactId-1_0", releaseConfiguration.getScmReleaseLabel() );
-
-        // prepare
-        releaseConfiguration = new ReleaseDescriptor();
-        releaseConfiguration.setInteractive( false );
-        releaseConfiguration.mapReleaseVersion( "groupId:artifactId", "1.0" );
-        releaseConfiguration.setScmSourceUrl( "scm:cvs:pserver:anoncvs@localhost:/tmp/scm-repo:module" );
-
-        // execute
-        phase.simulate( releaseConfiguration, new DefaultReleaseEnvironment(), reactorProjects );
-
-        // verify
-        assertEquals( "Check tag", "artifactId-1_0", releaseConfiguration.getScmReleaseLabel() );
-
-        // never use prompter
-        verifyNoMoreInteractions( mockPrompter );
-    }
-
-    // MRELEASE-159
-    @Test
-    public void testCustomTagFormat()
-        throws Exception
-    {
-        // prepare
-        Prompter mockPrompter = mock( Prompter.class );
-        phase.setPrompter( mockPrompter );
-
-        List<MavenProject> reactorProjects = Collections.singletonList( createProject( "artifactId", "1.0" ) );
-        ReleaseDescriptor releaseDescriptor = new ReleaseDescriptor();
-        releaseDescriptor.setInteractive( false );
-        releaseDescriptor.mapReleaseVersion( "groupId:artifactId", "1.0" );
-        releaseDescriptor.setScmSourceUrl( "scm:svn:file://localhost/tmp/scm-repo" );
-
-        // execute
-        phase.execute( releaseDescriptor, new DefaultReleaseEnvironment(), reactorProjects );
-
-        // verify
-        assertEquals( "Check tag", "artifactId-1.0", releaseDescriptor.getScmReleaseLabel() );
-
-        // prepare
-        releaseDescriptor = new ReleaseDescriptor();
-        releaseDescriptor.setInteractive( false );
-        releaseDescriptor.mapReleaseVersion( "groupId:artifactId", "1.0" );
-        releaseDescriptor.setScmSourceUrl( "scm:svn:file://localhost/tmp/scm-repo" );
-        releaseDescriptor.setScmTagNameFormat( "simulated-@{artifactId}-@{version}" );
-
-        // execute
-        phase.simulate( releaseDescriptor, new DefaultReleaseEnvironment(), reactorProjects );
-
-        // verify
-        assertEquals( "Check tag", "simulated-artifactId-1.0", releaseDescriptor.getScmReleaseLabel() );
-
-        // never use prompter
-        verifyNoMoreInteractions( mockPrompter );
-    }
 
     @Test
     public void testBranchOperation()
         throws Exception
     {
-        assertFalse( phase.isBranchOperation() );
+        assertTrue( phase.isBranchOperation() );
+    }
+
+    @Test
+    public void testEmptyBranchName()
+        throws Exception
+    {
+        // prepare
+        Prompter mockPrompter = mock( Prompter.class );
+        phase.setPrompter( mockPrompter );
+
+        List<MavenProject> reactorProjects = Collections.singletonList( createProject( "artifactId", "1.0" ) );
+
+        ReleaseDescriptor releaseDescriptor = new ReleaseDescriptor();
+        releaseDescriptor.setInteractive( false );
+        releaseDescriptor.setScmReleaseLabel( null );
+        releaseDescriptor.mapReleaseVersion( "groupId:artifactId", "1.0" );
+        releaseDescriptor.setScmSourceUrl( "scm:svn:file://localhost/tmp/scm-repo" );
+
+        // execute
+        try
+        {
+            phase.execute( releaseDescriptor, new DefaultReleaseEnvironment(), reactorProjects );
+
+            fail( "Expected an exception" );
+        }
+        catch ( ReleaseExecutionException e )
+        {
+            assertEquals( "No branch name was given.", e.getMessage() );
+        }
+
+        // prepare
+        releaseDescriptor = new ReleaseDescriptor();
+        releaseDescriptor.setInteractive( false );
+        releaseDescriptor.setScmReleaseLabel( null );
+        releaseDescriptor.mapReleaseVersion( "groupId:artifactId", "1.0" );
+        releaseDescriptor.setScmSourceUrl( "scm:svn:file://localhost/tmp/scm-repo" );
+
+        // execute
+        try
+        {
+            phase.simulate( releaseDescriptor, new DefaultReleaseEnvironment(), reactorProjects );
+
+            fail( "Expected an exception" );
+        }
+        catch ( ReleaseExecutionException e )
+        {
+            assertEquals( "No branch name was given.", e.getMessage() );
+        }
+
+        // never use prompter
+        verifyNoMoreInteractions( mockPrompter );
     }
 
 

--- a/maven-release-plugin/src/main/java/org/apache/maven/plugins/release/BranchReleaseMojo.java
+++ b/maven-release-plugin/src/main/java/org/apache/maven/plugins/release/BranchReleaseMojo.java
@@ -49,8 +49,8 @@ public class BranchReleaseMojo
      * @required
      * @since 2.0-beta-6
      */
-    @Parameter( property = "branchName", required = true )
-    private String branchName;
+    @Parameter( property = "branchName" )
+    private String branchName = null;
 
     /**
      * The branch base directory in SVN, you must define it if you don't use the standard svn layout
@@ -174,7 +174,7 @@ public class BranchReleaseMojo
     private String checkModificationExcludeList;
 
     /**
-     * Specify the new version for the branch. 
+     * Specify the new version for the branch.
      * This parameter is only meaningful if {@link #updateBranchVersions} = {@code true}.
      *
      * @since 2.0


### PR DESCRIPTION
Make branchName in the BranchReleaseMojo no longer required.
Adds the InputVariablesPhase to the list of branch phases; change the prompt slightly
when doing a branch name input.