### PR TITLE
MRELEASE-979: Allow VersionPolicies to manage Branch and Tag names

### DIFF
--- a/maven-release-api/src/main/java/org/apache/maven/shared/release/policy/version/VersionPolicy.java
+++ b/maven-release-api/src/main/java/org/apache/maven/shared/release/policy/version/VersionPolicy.java
@@ -30,6 +30,12 @@ import org.apache.maven.shared.release.versions.VersionParseException;
 public interface VersionPolicy
 {
     /**
+     * Calculation of the branch or tag version from development version.
+     */
+    VersionPolicyResult getBranchOrTagVersion( VersionPolicyRequest request )
+        throws PolicyException, VersionParseException;
+
+    /**
      * Calculation of the release version from development state.
      */
     VersionPolicyResult getReleaseVersion( VersionPolicyRequest request )

--- a/maven-release-api/src/main/java/org/apache/maven/shared/release/policy/version/VersionPolicyRequest.java
+++ b/maven-release-api/src/main/java/org/apache/maven/shared/release/policy/version/VersionPolicyRequest.java
@@ -22,15 +22,17 @@ package org.apache.maven.shared.release.policy.version;
 import org.apache.maven.artifact.repository.metadata.Metadata;
 
 /**
- * 
+ *
  * @since 2.5.1 (MRELEASE-431)
  */
 public class VersionPolicyRequest
 {
 
     private String version;
-    
+
     private Metadata metaData;
+
+    private String proposal;
 
     public String getVersion()
     {
@@ -42,16 +44,26 @@ public class VersionPolicyRequest
         this.version = version;
         return this;
     }
-    
+
     public Metadata getMetaData()
     {
         return metaData;
     }
-    
+
     public VersionPolicyRequest setMetaData( Metadata metaData )
     {
         this.metaData = metaData;
         return this;
     }
-    
+
+    public String getProposal()
+    {
+        return proposal;
+    }
+
+    public VersionPolicyRequest setProposal( String proposal )
+    {
+        this.proposal = proposal;
+        return this;
+    }
 }

--- a/maven-release-manager/src/main/components-fragment.xml
+++ b/maven-release-manager/src/main/components-fragment.xml
@@ -238,6 +238,10 @@
         <requirement>
           <role>org.apache.maven.shared.release.scm.ScmRepositoryConfigurator</role>
         </requirement>
+        <requirement>
+          <role>org.apache.maven.shared.release.policy.version.VersionPolicy</role>
+          <field-name>versionPolicies</field-name>
+        </requirement>
       </requirements>
     </component>
     <component>
@@ -254,6 +258,10 @@
         </requirement>
         <requirement>
           <role>org.apache.maven.shared.release.scm.ScmRepositoryConfigurator</role>
+        </requirement>
+        <requirement>
+          <role>org.apache.maven.shared.release.policy.version.VersionPolicy</role>
+          <field-name>versionPolicies</field-name>
         </requirement>
       </requirements>
     </component>

--- a/maven-release-manager/src/main/java/org/apache/maven/shared/release/policies/DefaultVersionPolicy.java
+++ b/maven-release-manager/src/main/java/org/apache/maven/shared/release/policies/DefaultVersionPolicy.java
@@ -28,7 +28,7 @@ import org.apache.maven.shared.release.versions.VersionParseException;
 import org.codehaus.plexus.component.annotations.Component;
 
 /**
- * 
+ *
  * @author Robert Scholte
  */
 @Component( role = VersionPolicy.class, hint = "default" )
@@ -51,4 +51,9 @@ public class DefaultVersionPolicy
         return new VersionPolicyResult().setVersion( developmentVersion );
     }
 
+    public VersionPolicyResult getBranchOrTagVersion( VersionPolicyRequest request )
+        throws PolicyException, VersionParseException
+    {
+        return null;
+    }
 }

--- a/maven-release-manager/src/test/java/org/apache/maven/shared/release/phase/BranchInputVariablesPhaseTest.java
+++ b/maven-release-manager/src/test/java/org/apache/maven/shared/release/phase/BranchInputVariablesPhaseTest.java
@@ -71,6 +71,7 @@ public class BranchInputVariablesPhaseTest
         ReleaseDescriptor releaseDescriptor = new ReleaseDescriptor();
         releaseDescriptor.mapReleaseVersion( "groupId:artifactId", "1.0" );
         releaseDescriptor.setScmSourceUrl( "scm:svn:file://localhost/tmp/scm-repo" );
+        releaseDescriptor.setInteractive( true );
 
         // execute
         phase.execute( releaseDescriptor, new DefaultReleaseEnvironment(), reactorProjects );
@@ -137,8 +138,10 @@ public class BranchInputVariablesPhaseTest
         List<MavenProject> reactorProjects = Collections.singletonList( createProject( "artifactId", "1.0" ) );
 
         ReleaseDescriptor releaseDescriptor = new ReleaseDescriptor();
+        releaseDescriptor.mapReleaseVersion( "groupId:artifactId", "1.0" );
         releaseDescriptor.setInteractive( false );
         releaseDescriptor.setScmReleaseLabel( "tag-value" );
+        releaseDescriptor.setScmSourceUrl( "scm:svn:file://localhost/tmp/scm-repo" );
 
         // execute
         phase.execute( releaseDescriptor, new DefaultReleaseEnvironment(), reactorProjects );
@@ -148,8 +151,10 @@ public class BranchInputVariablesPhaseTest
 
         // prepare
         releaseDescriptor = new ReleaseDescriptor();
+        releaseDescriptor.mapReleaseVersion( "groupId:artifactId", "1.0" );
         releaseDescriptor.setInteractive( false );
         releaseDescriptor.setScmReleaseLabel( "simulated-tag-value" );
+        releaseDescriptor.setScmSourceUrl( "scm:svn:file://localhost/tmp/scm-repo" );
 
         // execute
         phase.simulate( releaseDescriptor, new DefaultReleaseEnvironment(), reactorProjects );
@@ -172,7 +177,10 @@ public class BranchInputVariablesPhaseTest
         List<MavenProject> reactorProjects = Collections.singletonList( createProject( "artifactId", "1.0" ) );
 
         ReleaseDescriptor releaseDescriptor = new ReleaseDescriptor();
+        releaseDescriptor.mapReleaseVersion( "groupId:artifactId", "1.0" );
         releaseDescriptor.setScmReleaseLabel( "tag-value" );
+        releaseDescriptor.setScmSourceUrl( "scm:svn:file://localhost/tmp/scm-repo" );
+        releaseDescriptor.setInteractive( true );
 
         // execute
         phase.execute( releaseDescriptor, new DefaultReleaseEnvironment(), reactorProjects );
@@ -182,7 +190,10 @@ public class BranchInputVariablesPhaseTest
 
         // prepare
         releaseDescriptor = new ReleaseDescriptor();
+        releaseDescriptor.mapReleaseVersion( "groupId:artifactId", "1.0" );
         releaseDescriptor.setScmReleaseLabel( "simulated-tag-value" );
+        releaseDescriptor.setScmSourceUrl( "scm:svn:file://localhost/tmp/scm-repo" );
+        releaseDescriptor.setInteractive( true );
 
         // execute
         phase.simulate( releaseDescriptor, new DefaultReleaseEnvironment(), reactorProjects );
@@ -209,6 +220,7 @@ public class BranchInputVariablesPhaseTest
         ReleaseDescriptor releaseDescriptor = new ReleaseDescriptor();
         releaseDescriptor.mapReleaseVersion( "groupId:artifactId", "1.0" );
         releaseDescriptor.setScmSourceUrl( "scm:svn:file://localhost/tmp/scm-repo" );
+        releaseDescriptor.setInteractive( true );
 
         // execute
         try
@@ -226,6 +238,7 @@ public class BranchInputVariablesPhaseTest
         releaseDescriptor = new ReleaseDescriptor();
         releaseDescriptor.mapReleaseVersion( "groupId:artifactId", "1.0" );
         releaseDescriptor.setScmSourceUrl( "scm:svn:file://localhost/tmp/scm-repo" );
+        releaseDescriptor.setInteractive( true );
 
         // execute
         try

--- a/maven-release-manager/src/test/java/org/apache/maven/shared/release/phase/InputVariablesPhaseTest.java
+++ b/maven-release-manager/src/test/java/org/apache/maven/shared/release/phase/InputVariablesPhaseTest.java
@@ -73,6 +73,7 @@ public class InputVariablesPhaseTest
         ReleaseDescriptor releaseDescriptor = new ReleaseDescriptor();
         releaseDescriptor.mapReleaseVersion( "groupId:artifactId", "1.0" );
         releaseDescriptor.setScmSourceUrl( "scm:svn:file://localhost/tmp/scm-repo" );
+        releaseDescriptor.setInteractive( true );
 
         // execute
         phase.execute( releaseDescriptor, new DefaultReleaseEnvironment(), reactorProjects );
@@ -84,6 +85,7 @@ public class InputVariablesPhaseTest
         releaseDescriptor = new ReleaseDescriptor();
         releaseDescriptor.mapReleaseVersion( "groupId:artifactId", "1.0" );
         releaseDescriptor.setScmSourceUrl( "scm:svn:file://localhost/tmp/scm-repo" );
+        releaseDescriptor.setInteractive( true );
 
         // execute
         phase.simulate( releaseDescriptor, new DefaultReleaseEnvironment(), reactorProjects );
@@ -176,8 +178,10 @@ public class InputVariablesPhaseTest
         List<MavenProject> reactorProjects = Collections.singletonList( createProject( "artifactId", "1.0" ) );
 
         ReleaseDescriptor releaseDescriptor = new ReleaseDescriptor();
+        releaseDescriptor.mapReleaseVersion( "groupId:artifactId", "1.0" );
         releaseDescriptor.setInteractive( false );
         releaseDescriptor.setScmReleaseLabel( "tag-value" );
+        releaseDescriptor.setScmSourceUrl( "scm:svn:file://localhost/tmp/scm-repo" );
 
         // execute
         phase.execute( releaseDescriptor, new DefaultReleaseEnvironment(), reactorProjects );
@@ -187,8 +191,10 @@ public class InputVariablesPhaseTest
 
         // prepare
         releaseDescriptor = new ReleaseDescriptor();
+        releaseDescriptor.mapReleaseVersion( "groupId:artifactId", "1.0" );
         releaseDescriptor.setInteractive( false );
         releaseDescriptor.setScmReleaseLabel( "simulated-tag-value" );
+        releaseDescriptor.setScmSourceUrl( "scm:svn:file://localhost/tmp/scm-repo" );
 
         // execute
         phase.simulate( releaseDescriptor, new DefaultReleaseEnvironment(), reactorProjects );
@@ -206,12 +212,16 @@ public class InputVariablesPhaseTest
     {
         // prepare
         Prompter mockPrompter = mock( Prompter.class );
+
         phase.setPrompter( mockPrompter );
 
         List<MavenProject> reactorProjects = Collections.singletonList( createProject( "artifactId", "1.0" ) );
 
         ReleaseDescriptor releaseDescriptor = new ReleaseDescriptor();
+        releaseDescriptor.mapReleaseVersion( "groupId:artifactId", "1.0" );
         releaseDescriptor.setScmReleaseLabel( "tag-value" );
+        releaseDescriptor.setScmSourceUrl( "scm:svn:file://localhost/tmp/scm-repo" );
+        releaseDescriptor.setInteractive( true );
 
         // execute
         phase.execute( releaseDescriptor, new DefaultReleaseEnvironment(), reactorProjects );
@@ -221,7 +231,10 @@ public class InputVariablesPhaseTest
 
         // prepare
         releaseDescriptor = new ReleaseDescriptor();
+        releaseDescriptor.mapReleaseVersion( "groupId:artifactId", "1.0" );
         releaseDescriptor.setScmReleaseLabel( "simulated-tag-value" );
+        releaseDescriptor.setScmSourceUrl( "scm:svn:file://localhost/tmp/scm-repo" );
+        releaseDescriptor.setInteractive( true );
 
         // execute
         phase.simulate( releaseDescriptor, new DefaultReleaseEnvironment(), reactorProjects );
@@ -248,6 +261,7 @@ public class InputVariablesPhaseTest
         ReleaseDescriptor releaseDescriptor = new ReleaseDescriptor();
         releaseDescriptor.mapReleaseVersion( "groupId:artifactId", "1.0" );
         releaseDescriptor.setScmSourceUrl( "scm:svn:file://localhost/tmp/scm-repo" );
+        releaseDescriptor.setInteractive( true );
 
         // execute
         try
@@ -265,6 +279,7 @@ public class InputVariablesPhaseTest
         releaseDescriptor = new ReleaseDescriptor();
         releaseDescriptor.mapReleaseVersion( "groupId:artifactId", "1.0" );
         releaseDescriptor.setScmSourceUrl( "scm:svn:file://localhost/tmp/scm-repo" );
+        releaseDescriptor.setInteractive( true );
 
         // execute
         try

--- a/maven-release-policies/maven-release-oddeven-policy/src/main/java/org/apache/maven/shared/release/policy/oddeven/OddEvenVersionPolicy.java
+++ b/maven-release-policies/maven-release-oddeven-policy/src/main/java/org/apache/maven/shared/release/policy/oddeven/OddEvenVersionPolicy.java
@@ -60,6 +60,12 @@ public final class OddEvenVersionPolicy
         return calculateNextVersion( request, true );
     }
 
+    public VersionPolicyResult getBranchOrTagVersion(VersionPolicyRequest request)
+        throws PolicyException, VersionParseException
+    {
+        return null;
+    }
+
     private VersionPolicyResult calculateNextVersion( VersionPolicyRequest request, boolean development )
     {
         DefaultVersionInfo defaultVersionInfo = null;
@@ -123,5 +129,4 @@ public final class OddEvenVersionPolicy
 
         return mostSignificantSegment % 2 == 0;
     }
-
 }

--- a/maven-release-policies/maven-release-oddeven-policy/src/test/java/org/apache/maven/shared/release/policy/oddeven/OddEvenVersionPolicyTestCase.java
+++ b/maven-release-policies/maven-release-oddeven-policy/src/test/java/org/apache/maven/shared/release/policy/oddeven/OddEvenVersionPolicyTestCase.java
@@ -20,9 +20,11 @@ package org.apache.maven.shared.release.policy.oddeven;
  */
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
 
 import org.apache.maven.shared.release.policy.version.VersionPolicy;
 import org.apache.maven.shared.release.policy.version.VersionPolicyRequest;
+import org.apache.maven.shared.release.policy.version.VersionPolicyResult;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -72,6 +74,15 @@ public final class OddEvenVersionPolicyTestCase
                                                .getVersion();
 
         assertEquals( "1.0.2", suggestedVersion );
+    }
+
+    @Test
+    public void testBranchOrTag()
+        throws Exception
+    {
+        VersionPolicyResult result = versionPolicy.getBranchOrTagVersion( new VersionPolicyRequest().setVersion( "not used" ).setProposal( "1.0.1-SNAPSHOT" ) );
+
+        assertNull( result );
     }
 
     private static VersionPolicyRequest newVersionPolicyRequest( String version )

--- a/maven-release-policies/maven-release-semver-policy/src/main/java/org/apache/maven/shared/release/policy/semver/SemVerVersionPolicy.java
+++ b/maven-release-policies/maven-release-semver-policy/src/main/java/org/apache/maven/shared/release/policy/semver/SemVerVersionPolicy.java
@@ -40,7 +40,7 @@ public class SemVerVersionPolicy implements VersionPolicy
         throws PolicyException, VersionParseException
     {
         Version version;
-        try 
+        try
         {
             version = Version.parse( request.getVersion() );
         }
@@ -48,7 +48,7 @@ public class SemVerVersionPolicy implements VersionPolicy
         {
             throw new VersionParseException( e.getMessage() );
         }
-        
+
         VersionPolicyResult result = new VersionPolicyResult();
         result.setVersion( version.toReleaseVersion().toString() );
         return result;
@@ -58,7 +58,7 @@ public class SemVerVersionPolicy implements VersionPolicy
         throws PolicyException, VersionParseException
     {
         Version version;
-        try 
+        try
         {
             version = Version.parse( request.getVersion() );
         }
@@ -66,10 +66,16 @@ public class SemVerVersionPolicy implements VersionPolicy
         {
             throw new VersionParseException( e.getMessage() );
         }
-        
-        version = version.next( Element.MINOR );  
+
+        version = version.next( Element.MINOR );
         VersionPolicyResult result = new VersionPolicyResult();
         result.setVersion( version.toString() + "-SNAPSHOT" );
         return result;
+    }
+
+    public VersionPolicyResult getBranchOrTagVersion(VersionPolicyRequest request)
+        throws PolicyException, VersionParseException
+    {
+        return null;
     }
 }


### PR DESCRIPTION
Adds a new method to the VersionPolicy interface to allow
configuration of Branch and Tag names in a version policy.