### PR TITLE
[MRELEASE-979]: Allow VersionPolicies to manage Branch and Tag names

### DIFF
--- a/maven-release-api/src/main/java/org/apache/maven/shared/release/policy/naming/NamingPolicy.java
+++ b/maven-release-api/src/main/java/org/apache/maven/shared/release/policy/naming/NamingPolicy.java
@@ -1,0 +1,37 @@
+package org.apache.maven.shared.release.policy.naming;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import org.apache.maven.shared.release.policy.PolicyException;
+
+/**
+ * API for branch and tag naming. Used by maven-release-plugin to suggest names for tags and branches.
+ *
+ * @since 3.0.0 (MRELEASE-979)
+ */
+public interface NamingPolicy
+{
+    /**
+     * Calculation of the name used for branching or tagging.
+     */
+    NamingPolicyResult getName( NamingPolicyRequest request )
+        throws PolicyException;
+
+}

--- a/maven-release-api/src/main/java/org/apache/maven/shared/release/policy/naming/NamingPolicyRequest.java
+++ b/maven-release-api/src/main/java/org/apache/maven/shared/release/policy/naming/NamingPolicyRequest.java
@@ -1,0 +1,92 @@
+package org.apache.maven.shared.release.policy.naming;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/**
+ *
+ * @since 3.0.0 (MRELEASE-979)
+ */
+public class NamingPolicyRequest
+{
+
+    /**
+     * Artifact release version for which the branch or tag is created.
+     */
+    private String version;
+
+    /**
+     * Proposed name for the branch or tag.
+     */
+    private String name;
+
+    /**
+     * true if branch operation, false for tag operation.
+     */
+    private boolean branch;
+
+    /**
+     * Generated (from scmTagFormat and project settings) name proposal.
+     */
+    private String proposal;
+
+    public String getVersion()
+    {
+        return version;
+    }
+
+    public NamingPolicyRequest setVersion( String version )
+    {
+        this.version = version;
+        return this;
+    }
+
+    public String getName()
+    {
+        return name;
+    }
+
+    public NamingPolicyRequest setName( String name )
+    {
+        this.name = name;
+        return this;
+    }
+
+    public String getProposal()
+    {
+        return proposal;
+    }
+
+    public NamingPolicyRequest setProposal( String proposal )
+    {
+        this.proposal = proposal;
+        return this;
+    }
+
+    public boolean isBranch()
+    {
+        return branch;
+    }
+
+    public NamingPolicyRequest setBranch( boolean branch )
+    {
+        this.branch = branch;
+        return this;
+    }
+}

--- a/maven-release-api/src/main/java/org/apache/maven/shared/release/policy/naming/NamingPolicyResult.java
+++ b/maven-release-api/src/main/java/org/apache/maven/shared/release/policy/naming/NamingPolicyResult.java
@@ -1,0 +1,44 @@
+package org.apache.maven.shared.release.policy.naming;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/**
+ *
+ * @since 3.0.0 (MRELEASE-979)
+ */
+public class NamingPolicyResult
+{
+    /**
+     * The tag or branch name to use.
+     */
+    private String name;
+
+    public String getName()
+    {
+        return name;
+    }
+
+    public NamingPolicyResult setName( String name )
+    {
+        this.name = name;
+        return this;
+    }
+
+}

--- a/maven-release-manager/pom.xml
+++ b/maven-release-manager/pom.xml
@@ -211,7 +211,7 @@
           </execution>
         </executions>
         <configuration>
-          <version>2.5.1</version>
+          <version>3.0.0</version>
           <packageWithVersion>false</packageWithVersion>
           <useJava5>true</useJava5>
           <models>

--- a/maven-release-manager/src/main/components-fragment.xml
+++ b/maven-release-manager/src/main/components-fragment.xml
@@ -238,6 +238,10 @@
         <requirement>
           <role>org.apache.maven.shared.release.scm.ScmRepositoryConfigurator</role>
         </requirement>
+        <requirement>
+          <role>org.apache.maven.shared.release.policy.naming.NamingPolicy</role>
+          <field-name>namingPolicies</field-name>
+        </requirement>
       </requirements>
     </component>
     <component>
@@ -254,6 +258,10 @@
         </requirement>
         <requirement>
           <role>org.apache.maven.shared.release.scm.ScmRepositoryConfigurator</role>
+        </requirement>
+        <requirement>
+          <role>org.apache.maven.shared.release.policy.naming.NamingPolicy</role>
+          <field-name>namingPolicies</field-name>
         </requirement>
       </requirements>
     </component>

--- a/maven-release-manager/src/main/java/org/apache/maven/shared/release/config/ReleaseUtils.java
+++ b/maven-release-manager/src/main/java/org/apache/maven/shared/release/config/ReleaseUtils.java
@@ -124,6 +124,9 @@ public class ReleaseUtils
         mergeInto.setProjectVersionPolicyId(
             mergeDefault( mergeInto.getProjectVersionPolicyId(), toBeMerged.getProjectVersionPolicyId() ) );
 
+        mergeInto.setProjectNamingPolicyId(
+                mergeDefault( mergeInto.getProjectNamingPolicyId(), toBeMerged.getProjectNamingPolicyId() ) );
+
         return mergeInto;
     }
 
@@ -163,6 +166,7 @@ public class ReleaseUtils
         releaseDescriptor.setPreparationGoals( properties.getProperty( "preparationGoals" ) );
         releaseDescriptor.setCompletionGoals( properties.getProperty( "completionGoals" ) );
         releaseDescriptor.setProjectVersionPolicyId( properties.getProperty( "projectVersionPolicyId" ) );
+        releaseDescriptor.setProjectNamingPolicyId( properties.getProperty( "projectNamingPolicyId" ) );
         String snapshotReleasePluginAllowedStr = properties.getProperty( "exec.snapshotReleasePluginAllowed" );
         releaseDescriptor.setSnapshotReleasePluginAllowed( snapshotReleasePluginAllowedStr == null
                                                                ? false

--- a/maven-release-manager/src/main/java/org/apache/maven/shared/release/policies/DefaultNamingPolicy.java
+++ b/maven-release-manager/src/main/java/org/apache/maven/shared/release/policies/DefaultNamingPolicy.java
@@ -1,0 +1,50 @@
+package org.apache.maven.shared.release.policies;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import org.apache.maven.shared.release.policy.PolicyException;
+import org.apache.maven.shared.release.policy.naming.NamingPolicy;
+import org.apache.maven.shared.release.policy.naming.NamingPolicyRequest;
+import org.apache.maven.shared.release.policy.naming.NamingPolicyResult;
+import org.codehaus.plexus.component.annotations.Component;
+
+/**
+ * Implements backwards compatible naming policy. Returns the branch
+ * or tag name chosen by the release manager as is without any changes.
+ * If the name was null, returns null.
+ */
+@Component( role = NamingPolicy.class, hint = "default" )
+public class DefaultNamingPolicy
+    implements NamingPolicy
+{
+
+    public NamingPolicyResult getName( NamingPolicyRequest request )
+        throws PolicyException
+    {
+        if ( request == null )
+        {
+            return null;
+        }
+        else
+        {
+            return new NamingPolicyResult().setName( request.getName() );
+        }
+    }
+}

--- a/maven-release-manager/src/main/mdo/release-descriptor.mdo
+++ b/maven-release-manager/src/main/mdo/release-descriptor.mdo
@@ -443,6 +443,15 @@
             The role-hint for the VersionPolicy implementation used to calculate the project versions.
           </description>
         </field>
+        <field>
+          <name>projectNamingPolicyId</name>
+          <version>3.0.0+</version>
+          <type>String</type>
+          <defaultValue>default</defaultValue>
+          <description>
+            The role-hint for the NamingPolicy implementation used to calculate the project branch and tag names.
+          </description>
+        </field>
 
         <field>
           <name>remoteTagging</name>
@@ -869,7 +878,7 @@
             {
                 return true;
             }
-            
+
             if ( thisScm.getConnection() != null ? !thisScm.getConnection().equals( thatScm.getConnection() )
                 : thatScm.getConnection() != null )
             {
@@ -888,15 +897,15 @@
             {
                 return false;
             }
-            
+
             if ( thisScm instanceof org.apache.maven.shared.release.scm.IdentifiedScm && thatScm instanceof org.apache.maven.shared.release.scm.IdentifiedScm )
             {
-            	org.apache.maven.shared.release.scm.IdentifiedScm thisIdentifiedScm = (org.apache.maven.shared.release.scm.IdentifiedScm) thisScm;
-            	org.apache.maven.shared.release.scm.IdentifiedScm thatIdentifiedScm = (org.apache.maven.shared.release.scm.IdentifiedScm) thatScm;
-            	if ( thisIdentifiedScm.getId() != null ? !thisIdentifiedScm.getId().equals( thatIdentifiedScm.getId() ) : thatIdentifiedScm.getId() != null )
-            	{
-                	return false;
-            	}
+                org.apache.maven.shared.release.scm.IdentifiedScm thisIdentifiedScm = (org.apache.maven.shared.release.scm.IdentifiedScm) thisScm;
+                org.apache.maven.shared.release.scm.IdentifiedScm thatIdentifiedScm = (org.apache.maven.shared.release.scm.IdentifiedScm) thatScm;
+                if ( thisIdentifiedScm.getId() != null ? !thisIdentifiedScm.getId().equals( thatIdentifiedScm.getId() ) : thatIdentifiedScm.getId() != null )
+                {
+                    return false;
+                }
             }
         }
 

--- a/maven-release-manager/src/test/java/org/apache/maven/shared/release/phase/BranchInputVariablesPhaseTest.java
+++ b/maven-release-manager/src/test/java/org/apache/maven/shared/release/phase/BranchInputVariablesPhaseTest.java
@@ -71,6 +71,7 @@ public class BranchInputVariablesPhaseTest
         ReleaseDescriptor releaseDescriptor = new ReleaseDescriptor();
         releaseDescriptor.mapReleaseVersion( "groupId:artifactId", "1.0" );
         releaseDescriptor.setScmSourceUrl( "scm:svn:file://localhost/tmp/scm-repo" );
+        releaseDescriptor.setInteractive( true );
 
         // execute
         phase.execute( releaseDescriptor, new DefaultReleaseEnvironment(), reactorProjects );
@@ -137,8 +138,10 @@ public class BranchInputVariablesPhaseTest
         List<MavenProject> reactorProjects = Collections.singletonList( createProject( "artifactId", "1.0" ) );
 
         ReleaseDescriptor releaseDescriptor = new ReleaseDescriptor();
+        releaseDescriptor.mapReleaseVersion( "groupId:artifactId", "1.0" );
         releaseDescriptor.setInteractive( false );
         releaseDescriptor.setScmReleaseLabel( "tag-value" );
+        releaseDescriptor.setScmSourceUrl( "scm:svn:file://localhost/tmp/scm-repo" );
 
         // execute
         phase.execute( releaseDescriptor, new DefaultReleaseEnvironment(), reactorProjects );
@@ -148,8 +151,10 @@ public class BranchInputVariablesPhaseTest
 
         // prepare
         releaseDescriptor = new ReleaseDescriptor();
+        releaseDescriptor.mapReleaseVersion( "groupId:artifactId", "1.0" );
         releaseDescriptor.setInteractive( false );
         releaseDescriptor.setScmReleaseLabel( "simulated-tag-value" );
+        releaseDescriptor.setScmSourceUrl( "scm:svn:file://localhost/tmp/scm-repo" );
 
         // execute
         phase.simulate( releaseDescriptor, new DefaultReleaseEnvironment(), reactorProjects );
@@ -172,7 +177,10 @@ public class BranchInputVariablesPhaseTest
         List<MavenProject> reactorProjects = Collections.singletonList( createProject( "artifactId", "1.0" ) );
 
         ReleaseDescriptor releaseDescriptor = new ReleaseDescriptor();
+        releaseDescriptor.mapReleaseVersion( "groupId:artifactId", "1.0" );
         releaseDescriptor.setScmReleaseLabel( "tag-value" );
+        releaseDescriptor.setScmSourceUrl( "scm:svn:file://localhost/tmp/scm-repo" );
+        releaseDescriptor.setInteractive( true );
 
         // execute
         phase.execute( releaseDescriptor, new DefaultReleaseEnvironment(), reactorProjects );
@@ -182,7 +190,10 @@ public class BranchInputVariablesPhaseTest
 
         // prepare
         releaseDescriptor = new ReleaseDescriptor();
+        releaseDescriptor.mapReleaseVersion( "groupId:artifactId", "1.0" );
         releaseDescriptor.setScmReleaseLabel( "simulated-tag-value" );
+        releaseDescriptor.setScmSourceUrl( "scm:svn:file://localhost/tmp/scm-repo" );
+        releaseDescriptor.setInteractive( true );
 
         // execute
         phase.simulate( releaseDescriptor, new DefaultReleaseEnvironment(), reactorProjects );
@@ -209,6 +220,7 @@ public class BranchInputVariablesPhaseTest
         ReleaseDescriptor releaseDescriptor = new ReleaseDescriptor();
         releaseDescriptor.mapReleaseVersion( "groupId:artifactId", "1.0" );
         releaseDescriptor.setScmSourceUrl( "scm:svn:file://localhost/tmp/scm-repo" );
+        releaseDescriptor.setInteractive( true );
 
         // execute
         try
@@ -226,6 +238,7 @@ public class BranchInputVariablesPhaseTest
         releaseDescriptor = new ReleaseDescriptor();
         releaseDescriptor.mapReleaseVersion( "groupId:artifactId", "1.0" );
         releaseDescriptor.setScmSourceUrl( "scm:svn:file://localhost/tmp/scm-repo" );
+        releaseDescriptor.setInteractive( true );
 
         // execute
         try

--- a/maven-release-plugin/src/main/java/org/apache/maven/plugins/release/BranchReleaseMojo.java
+++ b/maven-release-plugin/src/main/java/org/apache/maven/plugins/release/BranchReleaseMojo.java
@@ -199,6 +199,14 @@ public class BranchReleaseMojo
     private String projectVersionPolicyId;
 
     /**
+     * The role-hint for the NamingPolicy implementation used to calculate the project branch and tag names.
+     *
+     * @since 3.0.0
+     */
+    @Parameter( defaultValue = "default", property = "projectNamingPolicyId" )
+    private String projectNamingPolicyId;
+
+    /**
      * {@inheritDoc}
      */
     public void execute()
@@ -222,6 +230,7 @@ public class BranchReleaseMojo
         config.setDefaultDevelopmentVersion( developmentVersion );
         config.setSuppressCommitBeforeTagOrBranch( suppressCommitBeforeBranch );
         config.setProjectVersionPolicyId( projectVersionPolicyId );
+        config.setProjectNamingPolicyId( projectNamingPolicyId );
 
         // Create a config containing values from the session properties (ie command line properties with cli).
         ReleaseDescriptor sysPropertiesConfig

--- a/maven-release-plugin/src/main/java/org/apache/maven/plugins/release/PrepareReleaseMojo.java
+++ b/maven-release-plugin/src/main/java/org/apache/maven/plugins/release/PrepareReleaseMojo.java
@@ -226,6 +226,14 @@ public class PrepareReleaseMojo
     private String projectVersionPolicyId;
 
     /**
+     * The role-hint for the NamingPolicy implementation used to calculate the project branch and tag names.
+     *
+     * @since 3.0.0
+     */
+    @Parameter( defaultValue = "default", property = "projectNamingPolicyId" )
+    private String projectNamingPolicyId;
+
+    /**
      * {@inheritDoc}
      */
     public void execute()
@@ -265,6 +273,7 @@ public class PrepareReleaseMojo
         config.setSuppressCommitBeforeTagOrBranch( suppressCommitBeforeTag );
         config.setWaitBeforeTagging( waitBeforeTagging );
         config.setProjectVersionPolicyId( projectVersionPolicyId );
+        config.setProjectNamingPolicyId( projectNamingPolicyId );
 
         if ( checkModificationExcludeList != null )
         {

--- a/maven-release-plugin/src/main/java/org/apache/maven/plugins/release/UpdateVersionsMojo.java
+++ b/maven-release-plugin/src/main/java/org/apache/maven/plugins/release/UpdateVersionsMojo.java
@@ -38,7 +38,7 @@ import org.apache.maven.shared.release.config.ReleaseUtils;
  * without making other modifications to the SCM such as tagging. For more info see <a
  * href="http://maven.apache.org/plugins/maven-release-plugin/examples/update-versions.html"
  * >http://maven.apache.org/plugins/maven-release-plugin/examples/update-versions.html</a>.
- * 
+ *
  * @author Paul Gier
  * @version $Id$
  * @since 2.0
@@ -51,7 +51,7 @@ public class UpdateVersionsMojo
     /**
      * Whether to automatically assign submodules the parent version. If set to false, the user will be prompted for the
      * version of each submodules.
-     * 
+     *
      * @since 2.0
      */
     @Parameter( defaultValue = "false", property = "autoVersionSubmodules" )
@@ -59,7 +59,7 @@ public class UpdateVersionsMojo
 
     /**
      * Whether to add a schema to the POM if it was previously missing on release.
-     * 
+     *
      * @since 2.0
      */
     @Parameter( defaultValue = "true", property = "addSchema" )
@@ -67,7 +67,7 @@ public class UpdateVersionsMojo
 
     /**
      * Default version to use for new local working copy.
-     * 
+     *
      * @since 2.0
      */
     @Parameter( property = "developmentVersion" )
@@ -83,7 +83,7 @@ public class UpdateVersionsMojo
 
     /**
      * Whether to use "edit" mode on the SCM, to lock the file for editing during SCM operations.
-     * 
+     *
      * @since 2.5.2
      */
     @Parameter( defaultValue = "false", property = "useEditMode" )
@@ -98,6 +98,14 @@ public class UpdateVersionsMojo
     private String projectVersionPolicyId;
 
     /**
+     * The role-hint for the NamingPolicy implementation used to calculate the project branch and tag names.
+     *
+     * @since 3.0.0
+     */
+    @Parameter( defaultValue = "default", property = "projectNamingPolicyId" )
+    private String projectNamingPolicyId;
+
+    /**
      * {@inheritDoc}
      */
     public void execute()
@@ -110,6 +118,7 @@ public class UpdateVersionsMojo
         config.setScmUseEditMode( useEditMode );
         config.setUpdateDependencies( updateDependencies );
         config.setProjectVersionPolicyId( projectVersionPolicyId );
+        config.setProjectNamingPolicyId( projectNamingPolicyId );
 
         Map<String, Scm> originalScmInfo = new HashMap<String, Scm>();
         originalScmInfo.put( ArtifactUtils.versionlessKey( project.getGroupId(), project.getArtifactId() ),


### PR DESCRIPTION
Introduces a new policy, NamingPolicy which allows managing branch and
tag names. This is similar but independent from the existing
VersionPolicy implementations.