### PR TITLE
MRELEASE-979 fixes 

### DIFF
--- a/maven-release-api/src/main/java/org/apache/maven/shared/release/policy/naming/NamingPolicy.java
+++ b/maven-release-api/src/main/java/org/apache/maven/shared/release/policy/naming/NamingPolicy.java
@@ -29,9 +29,15 @@ import org.apache.maven.shared.release.policy.PolicyException;
 public interface NamingPolicy
 {
     /**
-     * Calculation of the name used for branching or tagging.
+     * Calculation of the name used for branching.
      */
-    NamingPolicyResult getName( NamingPolicyRequest request )
+    NamingPolicyResult getBranchName( NamingPolicyRequest request )
+        throws PolicyException;
+
+    /**
+     * Calculation of the name used for tagging.
+     */
+    NamingPolicyResult getTagName( NamingPolicyRequest request )
         throws PolicyException;
 
 }

--- a/maven-release-api/src/main/java/org/apache/maven/shared/release/policy/naming/NamingPolicyRequest.java
+++ b/maven-release-api/src/main/java/org/apache/maven/shared/release/policy/naming/NamingPolicyRequest.java
@@ -20,16 +20,16 @@ package org.apache.maven.shared.release.policy.naming;
  */
 
 /**
- * 
+ *
  * @author Robert Scholte
  * @since 3.0.0
  */
 public class NamingPolicyRequest
 {
     private String groupId;
-    
+
     private String artifactId;
-    
+
     private String version;
 
     public String getGroupId()

--- a/maven-release-manager/src/main/java/org/apache/maven/shared/release/config/ReleaseUtils.java
+++ b/maven-release-manager/src/main/java/org/apache/maven/shared/release/config/ReleaseUtils.java
@@ -123,6 +123,8 @@ public class ReleaseUtils
 
         mergeInto.setProjectVersionPolicyId(
             mergeDefault( mergeInto.getProjectVersionPolicyId(), toBeMerged.getProjectVersionPolicyId() ) );
+        mergeInto.setProjectNamingPolicyId(
+                mergeDefault( mergeInto.getProjectNamingPolicyId(), toBeMerged.getProjectNamingPolicyId() ) );
 
         return mergeInto;
     }
@@ -163,6 +165,7 @@ public class ReleaseUtils
         releaseDescriptor.setPreparationGoals( properties.getProperty( "preparationGoals" ) );
         releaseDescriptor.setCompletionGoals( properties.getProperty( "completionGoals" ) );
         releaseDescriptor.setProjectVersionPolicyId( properties.getProperty( "projectVersionPolicyId" ) );
+        releaseDescriptor.setProjectNamingPolicyId( properties.getProperty( "projectNamingPolicyId" ) );
         String snapshotReleasePluginAllowedStr = properties.getProperty( "exec.snapshotReleasePluginAllowed" );
         releaseDescriptor.setSnapshotReleasePluginAllowed( snapshotReleasePluginAllowedStr == null
                                                                ? false

--- a/maven-release-manager/src/main/java/org/apache/maven/shared/release/policies/DefaultNamingPolicy.java
+++ b/maven-release-manager/src/main/java/org/apache/maven/shared/release/policies/DefaultNamingPolicy.java
@@ -26,7 +26,7 @@ import org.apache.maven.shared.release.policy.naming.NamingPolicyResult;
 import org.codehaus.plexus.component.annotations.Component;
 
 /**
- * 
+ *
  * @author Robert Scholte
  * @since 3.0.0
  */
@@ -34,9 +34,16 @@ import org.codehaus.plexus.component.annotations.Component;
 public class DefaultNamingPolicy implements NamingPolicy
 {
     @Override
-    public NamingPolicyResult getName( NamingPolicyRequest request )
+    public NamingPolicyResult getTagName( NamingPolicyRequest request )
         throws PolicyException
     {
         return new NamingPolicyResult().setName( request.getArtifactId() + "-" + request.getVersion() );
+    }
+
+    @Override
+    public NamingPolicyResult getBranchName( NamingPolicyRequest request )
+        throws PolicyException
+    {
+        return new NamingPolicyResult().setName( null );
     }
 }

--- a/maven-release-manager/src/test/java/org/apache/maven/shared/release/policies/DefaultNamingPolicyTest.java
+++ b/maven-release-manager/src/test/java/org/apache/maven/shared/release/policies/DefaultNamingPolicyTest.java
@@ -18,8 +18,8 @@ package org.apache.maven.shared.release.policies;
  * specific language governing permissions and limitations
  * under the License.
  */
-
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
 
 import org.apache.maven.shared.release.policy.naming.NamingPolicyRequest;
 import org.junit.Test;
@@ -27,16 +27,23 @@ import org.junit.Test;
 public class DefaultNamingPolicyTest
 {
     private DefaultNamingPolicy policy = new DefaultNamingPolicy();
-    
+
     @Test
-    public void testName() throws Exception
+    public void testTagName() throws Exception
     {
         assertEquals( "ARTIFACTID-VERSION",
-                      policy.getName( newNamingPolicyRequest( "ARTIFACTID", "VERSION" ) ).getName() );
+                      policy.getTagName( newNamingPolicyRequest( "ARTIFACTID", "VERSION" ) ).getName() );
         assertEquals( "ARTIFACTID-1.0-SNAPSHOT",
-                      policy.getName( newNamingPolicyRequest( "ARTIFACTID", "1.0-SNAPSHOT" ) ).getName() );
+                      policy.getTagName( newNamingPolicyRequest( "ARTIFACTID", "1.0-SNAPSHOT" ) ).getName() );
     }
-    
+
+    @Test
+    public void testBranchName() throws Exception
+    {
+        assertNull( policy.getBranchName( newNamingPolicyRequest( "ARTIFACTID", "VERSION" ) ).getName() );
+        assertNull( policy.getBranchName( newNamingPolicyRequest( "ARTIFACTID", "1.0-SNAPSHOT" ) ).getName() );
+    }
+
     private NamingPolicyRequest newNamingPolicyRequest( String artifactId, String version )
     {
         return new NamingPolicyRequest().setArtifactId( artifactId ).setVersion( version );


### PR DESCRIPTION
The proposed (and merged) change has the following problems (IAW it does not work at all):

- The selected naming policy is not copied in all places; especially it is not copied when merging with the properties loaded from the release.properties file. As a result, it always reverts to 'default'
- The current logic only executes the naming policy if the scmTagName is unset. This is counter-intuitive (to say the least). My original proposed patch did not have that problem. Change this to execute unconditionally if the operation requested is a branch operation, otherwise only if the scmTagName is unset
- The current logic failed unconditionally if the build is non-interactive and a branch operation is requested. 

This pull request fixes all of the mentioned problems. 