### PR TITLE
MRELEASE-979 - use split policies

### DIFF
--- a/maven-release-manager/src/main/java/org/apache/maven/shared/release/config/ReleaseUtils.java
+++ b/maven-release-manager/src/main/java/org/apache/maven/shared/release/config/ReleaseUtils.java
@@ -123,6 +123,8 @@ public class ReleaseUtils
 
         mergeInto.setProjectVersionPolicyId(
             mergeDefault( mergeInto.getProjectVersionPolicyId(), toBeMerged.getProjectVersionPolicyId() ) );
+        mergeInto.setProjectNamingPolicyId(
+            mergeDefault( mergeInto.getProjectNamingPolicyId(), toBeMerged.getProjectNamingPolicyId() ) );
 
         return mergeInto;
     }
@@ -163,6 +165,7 @@ public class ReleaseUtils
         releaseDescriptor.setPreparationGoals( properties.getProperty( "preparationGoals" ) );
         releaseDescriptor.setCompletionGoals( properties.getProperty( "completionGoals" ) );
         releaseDescriptor.setProjectVersionPolicyId( properties.getProperty( "projectVersionPolicyId" ) );
+        releaseDescriptor.setProjectNamingPolicyId( properties.getProperty( "projectNamingPolicyId" ) );
         String snapshotReleasePluginAllowedStr = properties.getProperty( "exec.snapshotReleasePluginAllowed" );
         releaseDescriptor.setSnapshotReleasePluginAllowed( snapshotReleasePluginAllowedStr == null
                                                                ? false

--- a/maven-release-manager/src/main/java/org/apache/maven/shared/release/phase/InputVariablesPhase.java
+++ b/maven-release-manager/src/main/java/org/apache/maven/shared/release/phase/InputVariablesPhase.java
@@ -74,7 +74,7 @@ public class InputVariablesPhase
      */
     @Requirement
     private ScmRepositoryConfigurator scmRepositoryConfigurator;
-    
+
     /**
      * Component used for custom or default naming policy
      */
@@ -134,9 +134,11 @@ public class InputVariablesPhase
                 throw new ReleaseExecutionException( "Project tag cannot be selected if version is not yet mapped" );
             }
 
-            String defaultTag;
+            String defaultTag = null;
             String scmTagNameFormat = releaseDescriptor.getScmTagNameFormat();
-            if ( scmTagNameFormat != null )
+
+            // Only apply the scmTagName format for tag operations, not branching.
+            if ( !branchOperation && scmTagNameFormat != null )
             {
                 Interpolator interpolator = new StringSearchInterpolator( "@{", "}" );
                 List<String> possiblePrefixes = java.util.Arrays.asList( "project", "pom" );
@@ -156,7 +158,8 @@ public class InputVariablesPhase
                         "Could not interpolate specified tag name format: " + scmTagNameFormat, e );
                 }
             }
-            else
+
+            if ( defaultTag == null )
             {
                 try
                 {
@@ -166,7 +169,7 @@ public class InputVariablesPhase
                 catch ( PolicyException e )
                 {
                     throw new ReleaseExecutionException( e.getMessage(), e );
-                } 
+                }
             }
 
             ScmProvider provider = null;
@@ -207,9 +210,16 @@ public class InputVariablesPhase
                                                          e );
                 }
             }
-            else if ( branchOperation )
+            else if ( defaultTag == null )
             {
-                throw new ReleaseExecutionException( "No branch name was given." );
+                if ( branchOperation )
+                {
+                    throw new ReleaseExecutionException( "No branch name was given." );
+                }
+                else
+                {
+                    throw new ReleaseExecutionException( "No tag name was given." );
+                }
             }
             else
             {
@@ -236,7 +246,7 @@ public class InputVariablesPhase
 
         return result;
     }
-    
+
     private String resolveSuggestedName( String policyId, String version, MavenProject project )
         throws PolicyException
     {

--- a/maven-release-manager/src/main/java/org/apache/maven/shared/release/policies/DefaultBranchNamingPolicy.java
+++ b/maven-release-manager/src/main/java/org/apache/maven/shared/release/policies/DefaultBranchNamingPolicy.java
@@ -1,0 +1,41 @@
+package org.apache.maven.shared.release.policies;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import org.apache.maven.shared.release.policy.PolicyException;
+import org.apache.maven.shared.release.policy.naming.NamingPolicy;
+import org.apache.maven.shared.release.policy.naming.NamingPolicyRequest;
+import org.apache.maven.shared.release.policy.naming.NamingPolicyResult;
+import org.codehaus.plexus.component.annotations.Component;
+
+/**
+ *
+ * @since 3.0.0
+ */
+@Component( role = NamingPolicy.class, hint = "default-branch" )
+public class DefaultBranchNamingPolicy implements NamingPolicy
+{
+    @Override
+    public NamingPolicyResult getName( NamingPolicyRequest request )
+        throws PolicyException
+    {
+        return new NamingPolicyResult().setName( null );
+    }
+}

--- a/maven-release-manager/src/test/java/org/apache/maven/shared/release/phase/BranchInputVariablesPhaseTest.java
+++ b/maven-release-manager/src/test/java/org/apache/maven/shared/release/phase/BranchInputVariablesPhaseTest.java
@@ -68,7 +68,7 @@ public class BranchInputVariablesPhaseTest
 
         List<MavenProject> reactorProjects = Collections.singletonList( createProject( "artifactId", "1.0" ) );
 
-        ReleaseDescriptor releaseDescriptor = new ReleaseDescriptor();
+        ReleaseDescriptor releaseDescriptor = createReleaseDescriptor();
         releaseDescriptor.mapReleaseVersion( "groupId:artifactId", "1.0" );
         releaseDescriptor.setScmSourceUrl( "scm:svn:file://localhost/tmp/scm-repo" );
 
@@ -79,7 +79,7 @@ public class BranchInputVariablesPhaseTest
         assertEquals( "Check tag", "tag-value", releaseDescriptor.getScmReleaseLabel() );
 
         // prepare
-        releaseDescriptor = new ReleaseDescriptor();
+        releaseDescriptor = createReleaseDescriptor();
         releaseDescriptor.mapReleaseVersion( "groupId:artifactId", "1.0" );
         releaseDescriptor.setScmSourceUrl( "scm:svn:file://localhost/tmp/scm-repo" );
 
@@ -99,7 +99,7 @@ public class BranchInputVariablesPhaseTest
     {
         List<MavenProject> reactorProjects = Collections.singletonList( createProject( "artifactId", "1.0" ) );
 
-        ReleaseDescriptor releaseDescriptor = new ReleaseDescriptor();
+        ReleaseDescriptor releaseDescriptor = createReleaseDescriptor();
 
         try
         {
@@ -112,7 +112,7 @@ public class BranchInputVariablesPhaseTest
             assertNull( "check no cause", e.getCause() );
         }
 
-        releaseDescriptor = new ReleaseDescriptor();
+        releaseDescriptor = createReleaseDescriptor();
 
         try
         {
@@ -136,7 +136,7 @@ public class BranchInputVariablesPhaseTest
 
         List<MavenProject> reactorProjects = Collections.singletonList( createProject( "artifactId", "1.0" ) );
 
-        ReleaseDescriptor releaseDescriptor = new ReleaseDescriptor();
+        ReleaseDescriptor releaseDescriptor = createReleaseDescriptor();
         releaseDescriptor.setInteractive( false );
         releaseDescriptor.setScmReleaseLabel( "tag-value" );
 
@@ -147,7 +147,7 @@ public class BranchInputVariablesPhaseTest
         assertEquals( "Check tag", "tag-value", releaseDescriptor.getScmReleaseLabel() );
 
         // prepare
-        releaseDescriptor = new ReleaseDescriptor();
+        releaseDescriptor = createReleaseDescriptor();
         releaseDescriptor.setInteractive( false );
         releaseDescriptor.setScmReleaseLabel( "simulated-tag-value" );
 
@@ -171,7 +171,7 @@ public class BranchInputVariablesPhaseTest
 
         List<MavenProject> reactorProjects = Collections.singletonList( createProject( "artifactId", "1.0" ) );
 
-        ReleaseDescriptor releaseDescriptor = new ReleaseDescriptor();
+        ReleaseDescriptor releaseDescriptor = createReleaseDescriptor();
         releaseDescriptor.setScmReleaseLabel( "tag-value" );
 
         // execute
@@ -181,7 +181,7 @@ public class BranchInputVariablesPhaseTest
         assertEquals( "Check tag", "tag-value", releaseDescriptor.getScmReleaseLabel() );
 
         // prepare
-        releaseDescriptor = new ReleaseDescriptor();
+        releaseDescriptor = createReleaseDescriptor();
         releaseDescriptor.setScmReleaseLabel( "simulated-tag-value" );
 
         // execute
@@ -206,7 +206,7 @@ public class BranchInputVariablesPhaseTest
 
         List<MavenProject> reactorProjects = Collections.singletonList( createProject( "artifactId", "1.0" ) );
 
-        ReleaseDescriptor releaseDescriptor = new ReleaseDescriptor();
+        ReleaseDescriptor releaseDescriptor = createReleaseDescriptor();
         releaseDescriptor.mapReleaseVersion( "groupId:artifactId", "1.0" );
         releaseDescriptor.setScmSourceUrl( "scm:svn:file://localhost/tmp/scm-repo" );
 
@@ -223,7 +223,7 @@ public class BranchInputVariablesPhaseTest
         }
 
         // prepare
-        releaseDescriptor = new ReleaseDescriptor();
+        releaseDescriptor = createReleaseDescriptor();
         releaseDescriptor.mapReleaseVersion( "groupId:artifactId", "1.0" );
         releaseDescriptor.setScmSourceUrl( "scm:svn:file://localhost/tmp/scm-repo" );
 
@@ -261,7 +261,7 @@ public class BranchInputVariablesPhaseTest
 
         List<MavenProject> reactorProjects = Collections.singletonList( createProject( "artifactId", "1.0" ) );
 
-        ReleaseDescriptor releaseDescriptor = new ReleaseDescriptor();
+        ReleaseDescriptor releaseDescriptor = createReleaseDescriptor();
         releaseDescriptor.setInteractive( false );
         releaseDescriptor.setScmReleaseLabel( null );
         releaseDescriptor.mapReleaseVersion( "groupId:artifactId", "1.0" );
@@ -280,7 +280,7 @@ public class BranchInputVariablesPhaseTest
         }
 
         // prepare
-        releaseDescriptor = new ReleaseDescriptor();
+        releaseDescriptor = createReleaseDescriptor();
         releaseDescriptor.setInteractive( false );
         releaseDescriptor.setScmReleaseLabel( null );
         releaseDescriptor.mapReleaseVersion( "groupId:artifactId", "1.0" );
@@ -309,5 +309,12 @@ public class BranchInputVariablesPhaseTest
         model.setArtifactId( artifactId );
         model.setVersion( version );
         return new MavenProject( model );
+    }
+
+    private static ReleaseDescriptor createReleaseDescriptor()
+    {
+        ReleaseDescriptor releaseDescriptor = new ReleaseDescriptor();
+        releaseDescriptor.setProjectNamingPolicyId("default-branch");
+        return releaseDescriptor;
     }
 }

--- a/maven-release-plugin/src/main/java/org/apache/maven/plugins/release/BranchReleaseMojo.java
+++ b/maven-release-plugin/src/main/java/org/apache/maven/plugins/release/BranchReleaseMojo.java
@@ -199,12 +199,12 @@ public class BranchReleaseMojo
     private String projectVersionPolicyId;
 
     /**
-     * The role-hint for the NamingPolicy implementation used to calculate the project branch and tag names.
+     * The role-hint for the NamingPolicy implementation used to calculate the project names.
      *
      * @since 3.0.0
      */
-    @Parameter( defaultValue = "default", property = "projectNamingPolicyId" )
-    private String projectNamingPolicyId;
+    @Parameter( defaultValue = "default-branch", property = "projectBranchNamingPolicyId" )
+    private String projectBranchNamingPolicyId;
 
     /**
      * {@inheritDoc}
@@ -230,7 +230,7 @@ public class BranchReleaseMojo
         config.setDefaultDevelopmentVersion( developmentVersion );
         config.setSuppressCommitBeforeTagOrBranch( suppressCommitBeforeBranch );
         config.setProjectVersionPolicyId( projectVersionPolicyId );
-        config.setProjectNamingPolicyId( projectNamingPolicyId );
+        config.setProjectNamingPolicyId( projectBranchNamingPolicyId );
 
         // Create a config containing values from the session properties (ie command line properties with cli).
         ReleaseDescriptor sysPropertiesConfig

--- a/maven-release-plugin/src/main/java/org/apache/maven/plugins/release/BranchReleaseMojo.java
+++ b/maven-release-plugin/src/main/java/org/apache/maven/plugins/release/BranchReleaseMojo.java
@@ -199,7 +199,7 @@ public class BranchReleaseMojo
     private String projectVersionPolicyId;
 
     /**
-     * The role-hint for the NamingPolicy implementation used to calculate the project names.
+     * The role-hint for the NamingPolicy implementation used to calculate the project branch names.
      *
      * @since 3.0.0
      */

--- a/maven-release-plugin/src/main/java/org/apache/maven/plugins/release/BranchReleaseMojo.java
+++ b/maven-release-plugin/src/main/java/org/apache/maven/plugins/release/BranchReleaseMojo.java
@@ -203,7 +203,7 @@ public class BranchReleaseMojo
      *
      * @since 3.0.0
      */
-    @Parameter( defaultValue = "default-branch", property = "projectBranchNamingPolicyId" )
+    @Parameter( defaultValue = "default-branch", property = "projectNamingPolicyId" )
     private String projectBranchNamingPolicyId;
 
     /**

--- a/maven-release-plugin/src/main/java/org/apache/maven/plugins/release/PrepareReleaseMojo.java
+++ b/maven-release-plugin/src/main/java/org/apache/maven/plugins/release/PrepareReleaseMojo.java
@@ -226,12 +226,12 @@ public class PrepareReleaseMojo
     private String projectVersionPolicyId;
 
     /**
-     * The role-hint for the NamingPolicy implementation used to calculate the project branch and tag names.
+     * The role-hint for the NamingPolicy implementation used to calculate the project tag names.
      *
      * @since 3.0.0
      */
-    @Parameter( defaultValue = "default", property = "projectNamingPolicyId" )
-    private String projectNamingPolicyId;
+    @Parameter( defaultValue = "default", property = "projectTagNamingPolicyId" )
+    private String projectTagNamingPolicyId;
 
     /**
      * {@inheritDoc}
@@ -273,7 +273,7 @@ public class PrepareReleaseMojo
         config.setSuppressCommitBeforeTagOrBranch( suppressCommitBeforeTag );
         config.setWaitBeforeTagging( waitBeforeTagging );
         config.setProjectVersionPolicyId( projectVersionPolicyId );
-        config.setProjectNamingPolicyId( projectNamingPolicyId );
+        config.setProjectNamingPolicyId( projectTagNamingPolicyId );
 
         if ( checkModificationExcludeList != null )
         {

--- a/maven-release-plugin/src/main/java/org/apache/maven/plugins/release/PrepareReleaseMojo.java
+++ b/maven-release-plugin/src/main/java/org/apache/maven/plugins/release/PrepareReleaseMojo.java
@@ -230,7 +230,7 @@ public class PrepareReleaseMojo
      *
      * @since 3.0.0
      */
-    @Parameter( defaultValue = "default", property = "projectTagNamingPolicyId" )
+    @Parameter( defaultValue = "default", property = "projectNamingPolicyId" )
     private String projectTagNamingPolicyId;
 
     /**


### PR DESCRIPTION
This is a rewrite of #14 to use split policies for branching and tagging as suggested by @rfscholte .