### PR TITLE
MRELEASE-985

### DIFF
--- a/maven-release-manager/src/main/java/org/apache/maven/shared/release/config/ReleaseUtils.java
+++ b/maven-release-manager/src/main/java/org/apache/maven/shared/release/config/ReleaseUtils.java
@@ -103,6 +103,8 @@ public class ReleaseUtils
         mergeInto.setPushChanges( toBeMerged.isPushChanges() );
         mergeInto.setWaitBeforeTagging( toBeMerged.getWaitBeforeTagging() );
 
+        mergeInto.setResolvedSnapshotDependencies( toBeMerged.getResolvedSnapshotDependencies() );
+
         // If the user specifies versions, these should be override the existing versions
         if ( toBeMerged.getReleaseVersions() != null )
         {

--- a/maven-release-manager/src/main/java/org/apache/maven/shared/release/phase/CheckDependencySnapshotsPhase.java
+++ b/maven-release-manager/src/main/java/org/apache/maven/shared/release/phase/CheckDependencySnapshotsPhase.java
@@ -110,7 +110,7 @@ public class CheckDependencySnapshotsPhase
         }
         else
         {
-            logInfo( result, "Ignoring SNAPSHOT depenedencies and plugins ..." );
+            logInfo( result, "Ignoring SNAPSHOT dependencies and plugins ..." );
         }
         result.setResultCode( ReleaseResult.SUCCESS );
 
@@ -131,7 +131,7 @@ public class CheckDependencySnapshotsPhase
                 usedSnapshotDependencies.add( project.getParentArtifact() );
             }
         }
-        
+
         try
         {
             @SuppressWarnings( "unchecked" )
@@ -156,7 +156,7 @@ public class CheckDependencySnapshotsPhase
         @SuppressWarnings( "unchecked" )
         Set<Artifact> extensionArtifacts = project.getExtensionArtifacts();
         checkExtensions( originalVersions, releaseDescriptor, artifactMap, extensionArtifacts );
-        
+
         //@todo check profiles
 
         if ( !usedSnapshotDependencies.isEmpty() || !usedSnapshotReports.isEmpty()
@@ -315,13 +315,21 @@ public class CheckDependencySnapshotsPhase
     private static boolean checkArtifact( Artifact artifact, Map<String, String> originalVersions,
                                           ReleaseDescriptor releaseDescriptor )
     {
+
         String versionlessArtifactKey = ArtifactUtils.versionlessKey( artifact.getGroupId(), artifact.getArtifactId() );
+
+        if ( releaseDescriptor.getResolvedSnapshotDependencies().containsKey( versionlessArtifactKey ) )
+        {
+            artifact.setVersion( ( String ) ( ( Map ) releaseDescriptor.getResolvedSnapshotDependencies()
+                                                                       .get( versionlessArtifactKey ) )
+                            .get( ReleaseDescriptor.RELEASE_KEY ) );
+        }
 
         // We are only looking at dependencies external to the project - ignore anything found in the reactor as
         // it's version will be updated
         boolean result =
             artifact.isSnapshot()
-            && !artifact.getBaseVersion().equals( originalVersions.get( versionlessArtifactKey ) );
+                            && !artifact.getBaseVersion().equals( originalVersions.get( versionlessArtifactKey ) );
 
         // If we have a snapshot but allowTimestampedSnapshots is true, accept the artifact if the version
         // indicates that it is a timestamped snapshot.

--- a/maven-release-manager/src/test/java/org/apache/maven/shared/release/phase/CheckDependencySnapshotsPhaseTest.java
+++ b/maven-release-manager/src/test/java/org/apache/maven/shared/release/phase/CheckDependencySnapshotsPhaseTest.java
@@ -22,14 +22,18 @@ package org.apache.maven.shared.release.phase;
 import org.apache.maven.project.MavenProject;
 import org.apache.maven.shared.release.ReleaseExecutionException;
 import org.apache.maven.shared.release.ReleaseFailureException;
+import org.apache.maven.shared.release.ReleaseResult;
 import org.apache.maven.shared.release.config.ReleaseDescriptor;
 import org.apache.maven.shared.release.env.DefaultReleaseEnvironment;
 import org.codehaus.plexus.components.interactivity.Prompter;
 import org.codehaus.plexus.components.interactivity.PrompterException;
+import org.junit.Test;
+
 import static org.mockito.Mockito.*;
 
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -106,6 +110,42 @@ public class CheckDependencySnapshotsPhaseTest
 
         // successful execution is verification enough
         assertTrue( true );
+    }
+
+    // MRELEASE-985
+    public void testSnapshotDependenciesInProjectAndResolveFromCommandLine() throws Exception {
+        ReleaseDescriptor releaseDescriptor = new ReleaseDescriptor();
+        List<MavenProject> reactorProjects = createDescriptorFromProjects( "internal-snapshot-dependencies-no-reactor" );
+        releaseDescriptor.setInteractive( false );
+
+        final Map resolvedSnapshotDependencies = new HashMap();
+        Map releaseKeys = new HashMap();
+        releaseKeys.put( ReleaseDescriptor.RELEASE_KEY, "1.0" );
+        releaseKeys.put( ReleaseDescriptor.DEVELOPMENT_KEY, "1.1" );
+
+        resolvedSnapshotDependencies.put( "groupId:test", releaseKeys );
+
+        releaseDescriptor.setResolvedSnapshotDependencies( resolvedSnapshotDependencies );
+
+        try
+        {
+            phase.execute( releaseDescriptor, new DefaultReleaseEnvironment(), reactorProjects );
+            assertTrue( true );
+        }
+        catch ( ReleaseFailureException e )
+        {
+            fail( "There should be no failed execution" );
+        }
+
+        try
+        {
+            phase.simulate( releaseDescriptor, new DefaultReleaseEnvironment(), reactorProjects );
+            assertTrue( true );
+        }
+        catch ( ReleaseFailureException e )
+        {
+            fail( "There should be no failed execution" );
+        }
     }
 
     public void testSnapshotReleasePluginNonInteractive()

--- a/maven-release-manager/src/test/resources/projects/check-dependencies/internal-snapshot-dependencies-no-reactor/pom.xml
+++ b/maven-release-manager/src/test/resources/projects/check-dependencies/internal-snapshot-dependencies-no-reactor/pom.xml
@@ -1,0 +1,31 @@
+<!--
+  ~ Copyright 2005-2006 The Apache Software Foundation.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~      http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<project>
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>groupId</groupId>
+    <artifactId>artifactId</artifactId>
+    <version>1.0-SNAPSHOT</version>
+    <packaging>jar</packaging>
+
+    <dependencies>
+        <dependency>
+            <groupId>groupId</groupId>
+            <artifactId>test</artifactId>
+            <version>1.0-SNAPSHOT</version>
+        </dependency>
+    </dependencies>
+</project>

--- a/maven-release-plugin/src/main/java/org/apache/maven/plugins/release/AbstractReleaseMojo.java
+++ b/maven-release-plugin/src/main/java/org/apache/maven/plugins/release/AbstractReleaseMojo.java
@@ -315,5 +315,9 @@ public abstract class AbstractReleaseMojo
         {
             config.getDevelopmentVersions().putAll( sysPropertiesConfig.getDevelopmentVersions() );
         }
+        if ( sysPropertiesConfig.getResolvedSnapshotDependencies() != null )
+        {
+            config.getResolvedSnapshotDependencies().putAll( sysPropertiesConfig.getResolvedSnapshotDependencies() );
+        }
     }
 }


### PR DESCRIPTION
This commit copies resolved snapshot dependencies system properties to the release descriptor
and then checks if the those resolved snapshot dependencies contain the SNAPSHOT artifact before
before adding it as a SNAPSHOT dependency.

Fixes: https://issues.apache.org/jira/browse/MRELEASE-985