### PR TITLE
[MRELEASE-798] - allow additional files to be commited at release

### DIFF
--- a/maven-release-api/src/main/java/org/apache/maven/shared/release/config/ReleaseDescriptor.java
+++ b/maven-release-api/src/main/java/org/apache/maven/shared/release/config/ReleaseDescriptor.java
@@ -415,5 +415,5 @@ public interface ReleaseDescriptor
 
     void setScmSourceUrl( String scmUrl );
 
-
+    String getAdditionalCommittedIncludes();
 }

--- a/maven-release-manager/src/main/java/org/apache/maven/shared/release/config/PropertiesReleaseDescriptorStore.java
+++ b/maven-release-manager/src/main/java/org/apache/maven/shared/release/config/PropertiesReleaseDescriptorStore.java
@@ -134,6 +134,12 @@ public class PropertiesReleaseDescriptorStore
         {
             properties.setProperty( "commitByProject", "true" );
         }
+        
+        if (config.getAdditionalCommittedIncludes() != null)
+        {
+            properties.setProperty("additionalCommittedIncludes", config.getAdditionalCommittedIncludes());
+        }
+        
         properties.setProperty( "scm.url", config.getScmSourceUrl() );
         if ( config.getScmId() != null )
         {

--- a/maven-release-manager/src/main/java/org/apache/maven/shared/release/config/ReleaseDescriptorBuilder.java
+++ b/maven-release-manager/src/main/java/org/apache/maven/shared/release/config/ReleaseDescriptorBuilder.java
@@ -391,6 +391,12 @@ public class ReleaseDescriptorBuilder
         releaseDescriptor.addDependencyDevelopmentVersion( dependencyKey, version );
         return this;
     }
+    
+    public ReleaseDescriptorBuilder setAdditionalCommittedIncludes( String additionalCommittedIncludes )
+    {
+        releaseDescriptor.setAdditionalCommittedIncludes(additionalCommittedIncludes);
+        return this;
+    }
 
     BuilderReleaseDescriptor build()
     {

--- a/maven-release-manager/src/main/java/org/apache/maven/shared/release/config/ReleaseUtils.java
+++ b/maven-release-manager/src/main/java/org/apache/maven/shared/release/config/ReleaseUtils.java
@@ -145,6 +145,11 @@ public class ReleaseUtils
             String pushChanges = properties.getProperty( "pushChanges" );
             builder.setPushChanges( Boolean.valueOf( pushChanges ) );
         }
+        
+        if ( properties.containsKey( "additionalCommittedIncludes" ) )
+        {
+            builder.setAdditionalCommittedIncludes(properties.getProperty( "additionalCommittedIncludes" ));
+        }
 
         loadResolvedDependencies( properties, builder );
 

--- a/maven-release-manager/src/main/java/org/apache/maven/shared/release/phase/ScmCommitDevelopmentPhase.java
+++ b/maven-release-manager/src/main/java/org/apache/maven/shared/release/phase/ScmCommitDevelopmentPhase.java
@@ -83,9 +83,10 @@ public class ScmCommitDevelopmentPhase
             }
             if ( simulating )
             {
-                Collection<File> pomFiles = createPomFiles( releaseDescriptor, reactorProjects );
+                Collection<File> files = createPomFiles( releaseDescriptor, reactorProjects );
+                files.addAll(createAdditionalFiles(releaseDescriptor, reactorProjects));
                 logInfo( result,
-                         "Full run would be commit " + pomFiles.size() + " files with message: '" + message + "'" );
+                         "Full run would be commit " + files.size() + " files with message: '" + message + "'" );
             }
             else
             {

--- a/maven-release-manager/src/main/mdo/release-descriptor.mdo
+++ b/maven-release-manager/src/main/mdo/release-descriptor.mdo
@@ -518,6 +518,16 @@
           </description>
         </field>
 
+        <field>
+          <name>additionalCommittedIncludes</name>
+          <version>3.0.0+</version>
+          <type>String</type>
+          <description>
+            In some exceptions you want to commit some changes to the repository in addition to pom files. Changes
+            to files listed here will be committed.
+          </description>
+        </field> 
+
         <!-- Announcement Information
 
         Announcement related info, this can be a second part of the process.
@@ -867,6 +877,10 @@
         {
             return false;
         }
+        if ( !java.util.Objects.equals( additionalCommittedIncludes, that.getAdditionalCommittedIncludes() ) )
+        {
+            return false;
+        }
         if ( !java.util.Objects.deepEquals( projectVersions, that.getProjectVersions() ) )
         {
             return false;
@@ -991,6 +1005,7 @@
         result = 29 * result + java.util.Objects.hashCode( performGoals );
         result = 29 * result + java.util.Objects.hashCode( defaultReleaseVersion );
         result = 29 * result + java.util.Objects.hashCode( scmReleasedPomRevision );
+        result = 29 * result + java.util.Objects.hashCode( additionalCommittedIncludes );
 
         return result;
     }

--- a/maven-release-manager/src/test/java/org/apache/maven/shared/release/config/PropertiesReleaseDescriptorStoreTest.java
+++ b/maven-release-manager/src/test/java/org/apache/maven/shared/release/config/PropertiesReleaseDescriptorStoreTest.java
@@ -315,6 +315,7 @@ public class PropertiesReleaseDescriptorStoreTest
         scm.setConnection( "connection-write" );
         // omit optional elements
         builder.addOriginalScmInfo( "groupId:subproject1", scm );
+        builder.setAdditionalCommittedIncludes( "foo.txt" );
 
         return builder;
     }
@@ -449,6 +450,7 @@ public class PropertiesReleaseDescriptorStoreTest
         builder.addOriginalScmInfo( "groupId:artifactId2", scm );
         builder.addDependencyReleaseVersion( "external:artifactId",  "1.0" );
         builder.addDependencyDevelopmentVersion( "external:artifactId", "1.1-SNAPSHOT" );
+        builder.setAdditionalCommittedIncludes( "foo.txt" );
 
         return builder;
     }

--- a/maven-release-manager/src/test/java/org/apache/maven/shared/release/config/ReleaseUtilsTest.java
+++ b/maven-release-manager/src/test/java/org/apache/maven/shared/release/config/ReleaseUtilsTest.java
@@ -76,6 +76,10 @@ public class ReleaseUtilsTest
         assertFalse( "Check original comparison", configBuilder.build().equals( origConfig ) );
         configBuilder.setAdditionalArguments( origConfig.getAdditionalArguments() );
 
+        configBuilder.setAdditionalCommittedIncludes( other );
+        assertFalse( "Check original comparison", configBuilder.build().equals( origConfig ) );
+        configBuilder.setAdditionalCommittedIncludes( origConfig.getAdditionalCommittedIncludes() );
+        
         configBuilder.setAddSchema( !origConfig.isAddSchema() );
         assertFalse( "Check original comparison", configBuilder.build().equals( origConfig ) );
         configBuilder.setAddSchema( origConfig.isAddSchema() );
@@ -288,6 +292,7 @@ public class ReleaseUtilsTest
         releaseDescriptor.setAdditionalArguments( "additional-arguments" );
         releaseDescriptor.setPomFileName( "pom-file-name" );
         releaseDescriptor.setPreparationGoals( "preparation-goals" );
+        releaseDescriptor.setAdditionalCommittedIncludes( "foo.txt, bar.txt" );
 
         return releaseDescriptor;
     }

--- a/maven-release-manager/src/test/resources/release.properties
+++ b/maven-release-manager/src/test/resources/release.properties
@@ -36,6 +36,8 @@ exec.pomFileName=pom-file-name
 preparationGoals=preparation-goals
 completionGoals=completion-goals
 
+additionalCommittedIncludes=foo.txt
+
 project.rel.groupId\:artifactId1=2.0
 project.rel.groupId\:artifactId2=3.0
 project.dev.groupId\:artifactId1=2.1-SNAPSHOT

--- a/maven-release-plugin/src/main/java/org/apache/maven/plugins/release/PrepareReleaseMojo.java
+++ b/maven-release-plugin/src/main/java/org/apache/maven/plugins/release/PrepareReleaseMojo.java
@@ -29,6 +29,7 @@ import org.apache.maven.shared.release.ReleaseExecutionException;
 import org.apache.maven.shared.release.ReleaseFailureException;
 import org.apache.maven.shared.release.ReleasePrepareRequest;
 import org.apache.maven.shared.release.config.ReleaseDescriptorBuilder;
+import org.apache.maven.shared.utils.StringUtils;
 
 /**
  * Prepare for a release in SCM. Steps through several phases to ensure the POM is ready to be released and then
@@ -238,6 +239,22 @@ public class PrepareReleaseMojo
     @Parameter( property = "projectNamingPolicyId" )
     private String projectTagNamingPolicyId;
 
+    /**
+     * A list of additional include filters that will be commited with pom files. 
+     * 
+     * @since 3.0.0
+     */
+    @Parameter
+    private String[] additionalCommittedIncludes;
+    
+    /**
+     * Command-line version of additionalCommittedIncludes.
+     * 
+     * @since 3.0.0
+     */
+    @Parameter( property = "additionalCommittedIncludeList" )
+    private String additionalCommittedIncludeList;     
+
     @Override
     public void execute()
         throws MojoExecutionException, MojoFailureException
@@ -286,6 +303,16 @@ public class PrepareReleaseMojo
         if ( checkModificationExcludes != null )
         {
             config.setCheckModificationExcludes( Arrays.asList( checkModificationExcludes ) );
+        }
+        
+        if (additionalCommittedIncludeList != null)
+        {
+            additionalCommittedIncludes = additionalCommittedIncludeList.replaceAll( "\\s", "" ).split( "," );
+        }
+
+        if (additionalCommittedIncludes != null)
+        {
+            config.setAdditionalCommittedIncludes(StringUtils.join( additionalCommittedIncludes, "," ) );
         }
         
         ReleasePrepareRequest prepareRequest = new ReleasePrepareRequest();


### PR DESCRIPTION
replaces pull-request #4 which currently has merge conflicts.

@emenaceb is given credit for the work in the commit history but i wasn't about to deal w/ all the merge conflicts of rebasing 2.5/3 years worth of changes, so i just made them against what is currently in `master` and also added some tests where i could using existing functionality (`completionGoals`) as the example.