### PR TITLE
Fixes for MRELEASE-1009:

### DIFF
--- a/maven-release-manager/src/test/java/org/apache/maven/shared/release/transform/jdom/JDomPropertiesTest.java
+++ b/maven-release-manager/src/test/java/org/apache/maven/shared/release/transform/jdom/JDomPropertiesTest.java
@@ -105,7 +105,7 @@ public class JDomPropertiesTest
     public void testStoreToXMLEncoded()
         throws Exception
     {
-        new JDomProperties( null ).storeToXML( null, null, null );
+        new JDomProperties( null ).storeToXML( (OutputStream) null, null, (String) null );
     }
 
     @Test

--- a/pom.xml
+++ b/pom.xml
@@ -113,7 +113,7 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-surefire-plugin</artifactId>
-          <version>2.20.1</version>
+          <version>2.22.0</version>
         </plugin>
         <plugin>
           <groupId>org.codehaus.mojo</groupId>


### PR DESCRIPTION
- clean up ambigous reference in JUnit test
- upgrade Surefire to 2.22.0 to avoid a NullPointerException under Java 10 when executing "mvn package"