### PR TITLE
MRELEASE-985 Override snapshot dependencies from command line

### DIFF
--- a/maven-release-manager/src/main/java/org/apache/maven/shared/release/DefaultReleaseManager.java
+++ b/maven-release-manager/src/main/java/org/apache/maven/shared/release/DefaultReleaseManager.java
@@ -108,22 +108,36 @@ public class DefaultReleaseManager
 
         // Create a config containing values from the session properties (ie command line properties with cli).
         ReleaseUtils.copyPropertiesToReleaseDescriptor( prepareRequest.getUserProperties(),
-                                        new ReleaseDescriptorBuilder()
-                                        {
-                                            public ReleaseDescriptorBuilder addDevelopmentVersion( String key,
-                                                                                                   String value )
-                                            {
-                                                builder.addDevelopmentVersion( key, value );
-                                                return this;
-                                            }
+                new ReleaseDescriptorBuilder()
+                {
+                    public ReleaseDescriptorBuilder addDevelopmentVersion( String key,
+                                                                           String value )
+                    {
+                        builder.addDevelopmentVersion( key, value );
+                        return this;
+                    }
 
-                                            public ReleaseDescriptorBuilder addReleaseVersion( String key,
-                                                                                               String value )
-                                            {
-                                                builder.addReleaseVersion( key, value );
-                                                return this;
-                                            };
-                                        } );
+                    public ReleaseDescriptorBuilder addReleaseVersion( String key,
+                                                                       String value )
+                    {
+                        builder.addReleaseVersion( key, value );
+                        return this;
+                    }
+
+                    public ReleaseDescriptorBuilder addDependencyReleaseVersion( String dependencyKey,
+                                                                                String version )
+                    {
+                        builder.addDependencyReleaseVersion( dependencyKey, version );
+                        return this;
+                    }
+
+                    public ReleaseDescriptorBuilder addDependencyDevelopmentVersion( String dependencyKey,
+                                                                                    String version )
+                    {
+                        builder.addDependencyDevelopmentVersion( dependencyKey, version );
+                        return this;
+                    }
+                } );
 
         BuilderReleaseDescriptor config;
         if ( BooleanUtils.isNotFalse( prepareRequest.getResume() ) )
@@ -132,7 +146,7 @@ public class DefaultReleaseManager
         }
         else
         {
-            config = ReleaseUtils.buildReleaseDescriptor( prepareRequest.getReleaseDescriptorBuilder() );
+            config = ReleaseUtils.buildReleaseDescriptor( builder );
         }
 
         Strategy releaseStrategy = getStrategy( config.getReleaseStrategyId() );

--- a/maven-release-manager/src/test/java/org/apache/maven/shared/release/phase/CheckDependencySnapshotsPhaseTest.java
+++ b/maven-release-manager/src/test/java/org/apache/maven/shared/release/phase/CheckDependencySnapshotsPhaseTest.java
@@ -30,7 +30,9 @@ import static org.mockito.Mockito.when;
 
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 
 import org.apache.maven.project.MavenProject;
@@ -106,6 +108,35 @@ public class CheckDependencySnapshotsPhaseTest
 
         // successful execution is verification enough
         assertTrue( true );
+    }
+
+    // MRELEASE-985
+    @Test
+    public void testSnapshotDependenciesInProjectAndResolveFromCommandLine() throws Exception {
+        List<MavenProject> reactorProjects = createDescriptorFromProjects( "internal-snapshot-dependencies-no-reactor" );
+        ReleaseDescriptorBuilder builder = createReleaseDescriptorBuilder( reactorProjects );
+        builder.addDependencyReleaseVersion("groupId:test", "1.0");
+        builder.addDependencyDevelopmentVersion("groupId:test", "1.1");
+
+        try
+        {
+            phase.execute( ReleaseUtils.buildReleaseDescriptor( builder ), new DefaultReleaseEnvironment(), reactorProjects );
+            assertTrue( true );
+        }
+        catch ( ReleaseFailureException e )
+        {
+            fail( "There should be no failed execution" );
+        }
+
+        try
+        {
+            phase.simulate( ReleaseUtils.buildReleaseDescriptor( builder ), new DefaultReleaseEnvironment(), reactorProjects );
+            assertTrue( true );
+        }
+        catch ( ReleaseFailureException e )
+        {
+            fail( "There should be no failed execution" );
+        }
     }
 
     @Test
@@ -498,10 +529,10 @@ public class CheckDependencySnapshotsPhaseTest
                                                new VersionPair( "1.0", "1.0" ) ) );
 
         phase.execute( ReleaseUtils.buildReleaseDescriptor( builder ), new DefaultReleaseEnvironment(), reactorProjects );
- 
+
         // validate
         ReleaseDescriptor descriptor = ReleaseUtils.buildReleaseDescriptor( builder );
-        
+
         assertEquals( "1.0", descriptor.getDependencyReleaseVersion( "external:artifactId" ) );
         assertEquals( "1.1-SNAPSHOT", descriptor.getDependencyDevelopmentVersion( "external:artifactId" ) );
 

--- a/maven-release-manager/src/test/resources/projects/check-dependencies/internal-snapshot-dependencies-no-reactor/pom.xml
+++ b/maven-release-manager/src/test/resources/projects/check-dependencies/internal-snapshot-dependencies-no-reactor/pom.xml
@@ -1,0 +1,31 @@
+<!--
+  ~ Copyright 2005-2006 The Apache Software Foundation.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~      http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<project>
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>groupId</groupId>
+    <artifactId>artifactId</artifactId>
+    <version>1.0-SNAPSHOT</version>
+    <packaging>jar</packaging>
+
+    <dependencies>
+        <dependency>
+            <groupId>groupId</groupId>
+            <artifactId>test</artifactId>
+            <version>1.0-SNAPSHOT</version>
+        </dependency>
+    </dependencies>
+</project>


### PR DESCRIPTION
 - Copy properties to the correct release descriptor in DefaultReleaseManager.
 - Do not fail the build if the property is resolved from the comand-line (in CheckDependencySnapshotsPhase).

See https://issues.apache.org/jira/browse/MRELEASE-985