### PR TITLE
[MRELEASE-549] Add support for the "--pin-externals" operations in SCM branch and tag operations

### DIFF
--- a/maven-release-api/src/main/java/org/apache/maven/shared/release/config/ReleaseDescriptor.java
+++ b/maven-release-api/src/main/java/org/apache/maven/shared/release/config/ReleaseDescriptor.java
@@ -484,4 +484,12 @@ public interface ReleaseDescriptor
      * @return String
      */
     String getAutoResolveSnapshots();
+
+    /**
+     * Determines whether the <code>--pin-externals</code> option in svn copy commands is enabled
+     * which is new in Subversion 1.9.
+     * 
+     * @return boolean
+     */
+    boolean isPinExternals();
 }

--- a/maven-release-manager/src/main/java/org/apache/maven/shared/release/config/PropertiesReleaseDescriptorStore.java
+++ b/maven-release-manager/src/main/java/org/apache/maven/shared/release/config/PropertiesReleaseDescriptorStore.java
@@ -249,6 +249,8 @@ public class PropertiesReleaseDescriptorStore
 
         properties.setProperty( "remoteTagging", Boolean.toString( config.isRemoteTagging() ) );
 
+        properties.setProperty( "pinExternals", Boolean.toString( config.isPinExternals() ) );
+
         properties.setProperty( "pushChanges", Boolean.toString( config.isPushChanges() ) );
 
         if ( config.getWorkItem() != null )

--- a/maven-release-manager/src/main/java/org/apache/maven/shared/release/config/ReleaseDescriptorBuilder.java
+++ b/maven-release-manager/src/main/java/org/apache/maven/shared/release/config/ReleaseDescriptorBuilder.java
@@ -446,6 +446,12 @@ public class ReleaseDescriptorBuilder
         return this;
     }
 
+    public ReleaseDescriptorBuilder setPinExternals( boolean pinExternals )
+    {
+        releaseDescriptor.setPinExternals( pinExternals );
+        return this;
+    }
+
     BuilderReleaseDescriptor build()
     {
         return releaseDescriptor;

--- a/maven-release-manager/src/main/java/org/apache/maven/shared/release/config/ReleaseUtils.java
+++ b/maven-release-manager/src/main/java/org/apache/maven/shared/release/config/ReleaseUtils.java
@@ -161,6 +161,11 @@ public class ReleaseUtils
             String remoteTaggingStr = properties.getProperty( "remoteTagging" );
             builder.setRemoteTagging( Boolean.valueOf( remoteTaggingStr ) );
         }
+        if ( properties.containsKey( "pinExternals" ) )
+        {
+            String pinExternals = properties.getProperty( "pinExternals" );
+            builder.setPinExternals( Boolean.valueOf( pinExternals ) );
+        }
         if ( properties.containsKey( "pushChanges" ) )
         {
             String pushChanges = properties.getProperty( "pushChanges" );

--- a/maven-release-manager/src/main/java/org/apache/maven/shared/release/phase/ScmBranchPhase.java
+++ b/maven-release-manager/src/main/java/org/apache/maven/shared/release/phase/ScmBranchPhase.java
@@ -108,6 +108,7 @@ public class ScmBranchPhase
             scmBranchParameters.setMessage( releaseDescriptor.getScmCommentPrefix() + "copy for branch " + branchName );
             scmBranchParameters.setRemoteBranching( releaseDescriptor.isRemoteTagging() );
             scmBranchParameters.setScmRevision( releaseDescriptor.getScmReleasedPomRevision() );
+            scmBranchParameters.setPinExternals( releaseDescriptor.isPinExternals() );
 
             result = provider.branch( repository, fileSet, branchName, scmBranchParameters );
         }
@@ -143,6 +144,10 @@ public class ScmBranchPhase
             logInfo( result, "  To SCM URL: " + releaseDescriptor.getScmBranchBase() );
         }
         logInfo( result, "  with label: '" + releaseDescriptor.getScmReleaseLabel() + "'" );
+        if ( releaseDescriptor.isPinExternals() )
+        {
+            logInfo( result, "  with pinned externals" );
+        }
 
         result.setResultCode( ReleaseResult.SUCCESS );
 

--- a/maven-release-manager/src/main/java/org/apache/maven/shared/release/phase/ScmTagPhase.java
+++ b/maven-release-manager/src/main/java/org/apache/maven/shared/release/phase/ScmTagPhase.java
@@ -120,6 +120,7 @@ public class ScmTagPhase
                 new ScmTagParameters( releaseDescriptor.getScmCommentPrefix() + "copy for tag " + tagName );
             scmTagParameters.setRemoteTagging( releaseDescriptor.isRemoteTagging() );
             scmTagParameters.setScmRevision( releaseDescriptor.getScmReleasedPomRevision() );
+            scmTagParameters.setPinExternals( releaseDescriptor.isPinExternals() );
             if ( getLogger().isDebugEnabled() )
             {
                 getLogger().debug(
@@ -127,6 +128,8 @@ public class ScmTagPhase
                 getLogger().debug(
                     "ScmTagPhase :: scmTagParameters scmRevision " + releaseDescriptor.getScmReleasedPomRevision() );
                 getLogger().debug( "ScmTagPhase :: fileSet  " + fileSet );
+                getLogger().debug(
+                    "ScmTagPhase :: scmTagParameters pinExternals " + releaseDescriptor.isPinExternals() );
             }
             result = provider.tag( repository, fileSet, tagName, scmTagParameters );
         }
@@ -167,6 +170,10 @@ public class ScmTagPhase
         {
             logInfo( result, "Full run would be tagging remotely " + basedirAlignedReleaseDescriptor.getScmSourceUrl()
                 + " with label: '" + releaseDescriptor.getScmReleaseLabel() + "'" );
+        }
+        if ( releaseDescriptor.isPinExternals() )
+        {
+            logInfo( result, "Full run would pin externals" );
         }
 
         result.setResultCode( ReleaseResult.SUCCESS );

--- a/maven-release-manager/src/main/mdo/release-descriptor.mdo
+++ b/maven-release-manager/src/main/mdo/release-descriptor.mdo
@@ -583,6 +583,18 @@
           </description>
         </field>
 
+        <field>
+          <name>pinExternals</name>
+          <version>3.0.0+</version>
+          <type>boolean</type>
+          <defaultValue>false</defaultValue>
+          <description>
+            Enable the "--pin-externals" option in svn copy commands which is new in Subversion 1.9.
+            NOTE : Currently only implemented with Subversion.
+            (https://issues.apache.org/jira/browse/SCM-805)
+          </description>
+        </field>
+
         <!-- Announcement Information
 
         Announcement related info, this can be a second part of the process.
@@ -805,6 +817,7 @@
              updateVersionsToSnapshot         != that.isUpdateVersionsToSnapshot()         ||
              allowTimestampedSnapshots        != that.isAllowTimestampedSnapshots()        ||
              remoteTagging                    != that.isRemoteTagging()                    ||
+             pinExternals                     != that.isPinExternals()                     ||
              localCheckout                    != that.isLocalCheckout()                    ||
              pushChanges                      != that.isPushChanges()
            )
@@ -1076,6 +1089,7 @@
         result = 29 * result + java.util.Objects.hashCode( scmReleasedPomRevision );
         result = 29 * result + java.util.Objects.hashCode( workItem );
         result = 29 * result + java.util.Objects.hashCode( autoResolveSnapshots );
+        result = 29 * result + java.util.Objects.hashCode( pinExternals );
 
         return result;
     }

--- a/maven-release-manager/src/test/java/org/apache/maven/shared/release/phase/GenerateReleasePomsPhaseTest.java
+++ b/maven-release-manager/src/test/java/org/apache/maven/shared/release/phase/GenerateReleasePomsPhaseTest.java
@@ -117,6 +117,7 @@ public class GenerateReleasePomsPhaseTest
         builder.setGenerateReleasePoms( true );
         builder.setSuppressCommitBeforeTagOrBranch( true );
         builder.setRemoteTagging( false );
+        builder.setPinExternals( false );
         mapNextVersion( builder, "groupId:artifactId" );
 
         phase.execute( ReleaseUtils.buildReleaseDescriptor( builder ), new DefaultReleaseEnvironment(), reactorProjects );
@@ -135,6 +136,7 @@ public class GenerateReleasePomsPhaseTest
         builder.setGenerateReleasePoms( true );
         builder.setSuppressCommitBeforeTagOrBranch( true );
         builder.setRemoteTagging( true );
+        builder.setPinExternals( false );
         mapNextVersion( builder, "groupId:artifactId" );
 
         phase.execute( ReleaseUtils.buildReleaseDescriptor( builder ), new DefaultReleaseEnvironment(), reactorProjects );

--- a/maven-release-manager/src/test/java/org/apache/maven/shared/release/phase/IsScmBranchParametersEquals.java
+++ b/maven-release-manager/src/test/java/org/apache/maven/shared/release/phase/IsScmBranchParametersEquals.java
@@ -40,7 +40,7 @@ public class IsScmBranchParametersEquals extends ArgumentMatcher<ScmBranchParame
     {
         ScmBranchParameters sbp = (ScmBranchParameters) argument;
         return sbp.getMessage().equals( this.scmBranchParameters.getMessage() )
-            //&& stp.isRemoteTagging() == this.scmBranchParameters.isRemoteTagging()
-            ;
+            && sbp.isRemoteBranching() == this.scmBranchParameters.isRemoteBranching()
+            && sbp.isPinExternals() == this.scmBranchParameters.isPinExternals();
     }
 }

--- a/maven-release-manager/src/test/java/org/apache/maven/shared/release/phase/IsScmTagParametersEquals.java
+++ b/maven-release-manager/src/test/java/org/apache/maven/shared/release/phase/IsScmTagParametersEquals.java
@@ -39,6 +39,7 @@ public class IsScmTagParametersEquals extends ArgumentMatcher<ScmTagParameters>
     {
         ScmTagParameters stp = (ScmTagParameters) argument;
         return stp.getMessage().equals( this.scmTagParameters.getMessage() )
-            && stp.isRemoteTagging() == this.scmTagParameters.isRemoteTagging();
+            && stp.isRemoteTagging() == this.scmTagParameters.isRemoteTagging()
+            && stp.isPinExternals() == this.scmTagParameters.isPinExternals();
     }
 }

--- a/maven-release-manager/src/test/java/org/apache/maven/shared/release/phase/ScmCommitDevelopmentPhaseTest.java
+++ b/maven-release-manager/src/test/java/org/apache/maven/shared/release/phase/ScmCommitDevelopmentPhaseTest.java
@@ -96,6 +96,7 @@ public class ScmCommitDevelopmentPhaseTest
         List<MavenProject> reactorProjects = createReactorProjects();
 
         builder.setRemoteTagging( false );
+        builder.setPinExternals( false );
         builder.setSuppressCommitBeforeTagOrBranch( true );
         builder.setUpdateWorkingCopyVersions( false );
 

--- a/maven-release-manager/src/test/java/org/apache/maven/shared/release/phase/ScmCommitPreparationPhaseTest.java
+++ b/maven-release-manager/src/test/java/org/apache/maven/shared/release/phase/ScmCommitPreparationPhaseTest.java
@@ -488,6 +488,7 @@ public class ScmCommitPreparationPhaseTest
         List<MavenProject> reactorProjects = createReactorProjects();
 
         builder.setRemoteTagging( true );
+        builder.setPinExternals( false );
         builder.setSuppressCommitBeforeTagOrBranch( true );
 
         ScmProvider scmProviderMock = mock( ScmProvider.class );

--- a/maven-release-plugin/src/main/java/org/apache/maven/plugins/release/BranchReleaseMojo.java
+++ b/maven-release-plugin/src/main/java/org/apache/maven/plugins/release/BranchReleaseMojo.java
@@ -230,6 +230,15 @@ public class BranchReleaseMojo
     @Parameter( defaultValue = "@{prefix} prepare branch @{releaseLabel}", property = "scmBranchCommitComment" )
     private String scmBranchCommitComment = "@{prefix} prepare branch @{releaseLabel}";
 
+    /**
+     * Currently only implemented with svn scm. Enable the "--pin-externals" option in svn
+     * copy commands which is new in Subversion 1.9.
+     *
+     * @since 3.0.0
+     */
+    @Parameter( defaultValue = "false", property = "pinExternals" )
+    private boolean pinExternals;
+
     @Override
     public void execute()
         throws MojoExecutionException, MojoFailureException
@@ -254,6 +263,7 @@ public class BranchReleaseMojo
         config.setProjectVersionPolicyId( projectVersionPolicyId );
         config.setProjectNamingPolicyId( projectBranchNamingPolicyId );
         config.setScmBranchCommitComment( scmBranchCommitComment );
+        config.setPinExternals( pinExternals );
 
         if ( checkModificationExcludeList != null )
         {

--- a/maven-release-plugin/src/main/java/org/apache/maven/plugins/release/PrepareReleaseMojo.java
+++ b/maven-release-plugin/src/main/java/org/apache/maven/plugins/release/PrepareReleaseMojo.java
@@ -299,6 +299,15 @@ public class PrepareReleaseMojo
     private String autoResolveSnapshots;
 
     /**
+     * Currently only implemented with svn scm. Enable the <code>--pin-externals</code> option in svn
+     * copy commands which is new in Subversion 1.9.
+     *
+     * @since 3.0.0
+     */
+    @Parameter( defaultValue = "false", property = "pinExternals" )
+    private boolean pinExternals;
+
+    /**
      * {@inheritDoc}
      */
     @Override
@@ -343,6 +352,7 @@ public class PrepareReleaseMojo
         config.setScmDevelopmentCommitComment( scmDevelopmentCommitComment );
         config.setScmReleaseCommitComment( scmReleaseCommitComment );
         config.setAutoResolveSnapshots( autoResolveSnapshots );
+        config.setPinExternals( pinExternals );
 
         if ( checkModificationExcludeList != null )
         {

--- a/pom.xml
+++ b/pom.xml
@@ -81,6 +81,9 @@
     <contributor>
       <name>Henning Schmiedehausen</name>
     </contributor>
+    <contributor>
+      <name>Thorsten Heit</name>
+    </contributor>
   </contributors>
 
   <properties>


### PR DESCRIPTION
This PR adds support for the "--pin-externals" option in SCM branch and tag operations. This feature was introducted in Subversion 1.9 and is available in maven-scm-plugin since version 1.11.1.
See also
- https://issues.apache.org/jira/browse/MRELEASE-549
- https://issues.apache.org/jira/browse/SCM-805