### PR TITLE
[MRELEASE-1036] Fix JavaDoc for JDK 8

### DIFF
--- a/maven-release-api/src/main/java/org/apache/maven/shared/release/config/ReleaseDescriptor.java
+++ b/maven-release-api/src/main/java/org/apache/maven/shared/release/config/ReleaseDescriptor.java
@@ -109,7 +109,7 @@ public interface ReleaseDescriptor
     boolean isUpdateVersionsToSnapshot();
 
     /**
-     * Get nOTE : currently only implemented with svn scm. Enable a workaround to prevent issue due to svn client >
+     * Get nOTE : currently only implemented with svn scm. Enable a workaround to prevent issue due to svn client &gt;
      * 1.5.0 (https://issues.apache.org/jira/browse/SCM-406).
      * 
      * @return boolean
@@ -415,20 +415,23 @@ public interface ReleaseDescriptor
     String getReleaseStrategyId();
 
     /**
-     * Retrieve the original version for the resolved snapshot dependency.
+     * @return {@code String} The original version for the resolved snapshot dependency.
      *
+     * @param artifactKey the artifact key {@code String}
      */
     String getDependencyOriginalVersion( String artifactKey );
     
     /**
-     * Retrieve the release version for the resolved snapshot dependency.
+     * @return {@code String} the release version for the resolved snapshot dependency.
      *
+     * @param artifactKey the artifact key {@code String}
      */
     String getDependencyReleaseVersion( String artifactKey ); 
 
     /**
-     * Retrieve the release version for the resolved snapshot dependency.
+     * @return {@code String} the release version for the resolved snapshot dependency.
      *
+     * @param artifactKey the artifact key {@code String}
      */
     String getDependencyDevelopmentVersion( String artifactKey ); 
 
@@ -440,9 +443,9 @@ public interface ReleaseDescriptor
     String getProjectReleaseVersion( String key );
 
     /**
-     * Method getOriginalScmInfo.
+     * @return the original {@code Scm} information.
      * 
-     * @return Map
+     * @param projectKey the project key {@code String}
      */
     Scm getOriginalScmInfo( String projectKey );
 

--- a/maven-release-api/src/main/java/org/apache/maven/shared/release/policy/naming/NamingPolicy.java
+++ b/maven-release-api/src/main/java/org/apache/maven/shared/release/policy/naming/NamingPolicy.java
@@ -29,7 +29,11 @@ import org.apache.maven.shared.release.policy.PolicyException;
 public interface NamingPolicy
 {
     /**
-     * Calculation of the name used for branching or tagging.
+     * @return the calculation of the name used for branching or tagging.
+     * 
+     * @param request the {@code NamingPolicyRequest}
+     * 
+     * @throws PolicyException if exception in the policy
      */
     NamingPolicyResult getName( NamingPolicyRequest request )
         throws PolicyException;

--- a/maven-release-api/src/main/java/org/apache/maven/shared/release/policy/version/VersionPolicy.java
+++ b/maven-release-api/src/main/java/org/apache/maven/shared/release/policy/version/VersionPolicy.java
@@ -30,13 +30,23 @@ import org.apache.maven.shared.release.versions.VersionParseException;
 public interface VersionPolicy
 {
     /**
-     * Calculation of the release version from development state.
+     * @return the calculation of the release version from development state.
+     * 
+     * @param request the {@code VersionPolicyRequest}
+     *                
+     * @throws PolicyException if exception in the policy
+     * @throws VersionParseException if exception parsing the version
      */
     VersionPolicyResult getReleaseVersion( VersionPolicyRequest request )
         throws PolicyException, VersionParseException;
 
     /**
-     * Calculation of the next development version from release state.
+     * @return the calculation of the next development version from release state.
+     *
+     * @param request the {@code VersionPolicyRequest}
+     *
+     * @throws PolicyException if exception in the policy
+     * @throws VersionParseException if exception parsing the version
      */
     VersionPolicyResult getDevelopmentVersion( VersionPolicyRequest request )
         throws PolicyException, VersionParseException;

--- a/maven-release-api/src/main/java/org/apache/maven/shared/release/strategy/Strategy.java
+++ b/maven-release-api/src/main/java/org/apache/maven/shared/release/strategy/Strategy.java
@@ -32,37 +32,27 @@ import java.util.List;
 public interface Strategy
 {
     /**
-     * The release phases to execute the calling the prepare goal 
-     * 
-     * @return
+     * @return The release phases to execute the calling the prepare goal
      */
     List<String> getPreparePhases();
     
     /**
-     * The release phases to execute the calling the perform goal 
-     * 
-     * @return
+     * @return The release phases to execute the calling the perform goal 
      */
     List<String> getPerformPhases();
     
     /**
-     * The release phases to execute the calling the branch goal 
-     * 
-     * @return
+     * @return The release phases to execute the calling the branch goal 
      */
     List<String> getBranchPhases();
     
     /**
-     * The release phases to execute the calling the rollback goal 
-     * 
-     * @return
+     * @return The release phases to execute the calling the rollback goal 
      */
     List<String> getRollbackPhases();
     
     /**
-     * The release phases to execute the calling the update-versions goal 
-     * 
-     * @return
+     * @return The release phases to execute the calling the update-versions goal 
      */
     List<String> getUpdateVersionsPhases();
 }

--- a/maven-release-api/src/main/java/org/apache/maven/shared/release/versions/Version.java
+++ b/maven-release-api/src/main/java/org/apache/maven/shared/release/versions/Version.java
@@ -216,7 +216,8 @@ public class Version
     /**
      * Simply joins the items in the list with "." period
      * 
-     * @param digits
+     * @return a {@code String} containing the items in the list joined by "." period
+     * @param digits the list of digits {@code List<String>}
      */
     protected static String joinDigitString( List<String> digits )
     {

--- a/maven-release-manager/pom.xml
+++ b/maven-release-manager/pom.xml
@@ -260,6 +260,15 @@
           </execution>
         </executions>
       </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-javadoc-plugin</artifactId>
+        <configuration>
+          <!-- Excluding this package to avoid running doclint 
+          in generated sources for Modello -->
+          <excludePackageNames>org.apache.maven.shared.release.config</excludePackageNames>
+        </configuration>
+      </plugin>
     </plugins>
   </build>
 

--- a/maven-release-manager/src/main/java/org/apache/maven/shared/release/ReleaseManager.java
+++ b/maven-release-manager/src/main/java/org/apache/maven/shared/release/ReleaseManager.java
@@ -55,7 +55,7 @@ public interface ReleaseManager
      * Clean a release.
      *
      * @param cleanRequest all clean arguments
-     * @throws ReleaseFailureException 
+     * @throws ReleaseFailureException if exception when releasing
      * @since 2.3
      */
     void clean( ReleaseCleanRequest cleanRequest ) throws ReleaseFailureException;

--- a/maven-release-manager/src/main/java/org/apache/maven/shared/release/exec/ForkedMavenExecutor.java
+++ b/maven-release-manager/src/main/java/org/apache/maven/shared/release/exec/ForkedMavenExecutor.java
@@ -50,7 +50,7 @@ public class ForkedMavenExecutor
     @Requirement
     private CommandLineFactory commandLineFactory;
 
-    /**
+    /*
      * @noinspection UseOfSystemOutOrSystemErr
      */
     @Override

--- a/maven-release-manager/src/main/java/org/apache/maven/shared/release/phase/CheckDependencySnapshotsPhase.java
+++ b/maven-release-manager/src/main/java/org/apache/maven/shared/release/phase/CheckDependencySnapshotsPhase.java
@@ -49,9 +49,9 @@ import org.codehaus.plexus.components.interactivity.PrompterException;
  * Check the dependencies of all projects being released to see if there are any unreleased snapshots.
  *
  * @author <a href="mailto:brett@apache.org">Brett Porter</a>
- * @todo plugins with no version will be resolved to RELEASE which is not a snapshot, but remains unresolved to this point. This is a potential hole in the check, and should be revisited after the release pom writing is done and resolving versions to verify whether it is.
- * @todo plugins injected by the lifecycle are not tested here. They will be injected with a RELEASE version so are covered under the above point.
  */
+ // TODO plugins with no version will be resolved to RELEASE which is not a snapshot, but remains unresolved to this point. This is a potential hole in the check, and should be revisited after the release pom writing is done and resolving versions to verify whether it is.
+ // TODO plugins injected by the lifecycle are not tested here. They will be injected with a RELEASE version so are covered under the above point.
 @Component( role = ReleasePhase.class, hint = "check-dependency-snapshots" )
 public class CheckDependencySnapshotsPhase
     extends AbstractReleasePhase

--- a/maven-release-manager/src/main/java/org/apache/maven/shared/release/phase/MapVersionsPhase.java
+++ b/maven-release-manager/src/main/java/org/apache/maven/shared/release/phase/MapVersionsPhase.java
@@ -50,8 +50,8 @@ import org.codehaus.plexus.util.StringUtils;
  *  <dt>release:update-versions</dt><dd>map-development-versions; RD.isBranchCreation() = false</dd>
  * </dl>
  *
- * <p>
  * <table>
+ *   <caption>MapVersionsPhase</caption>
  *   <tr>
  *     <th>MapVersionsPhase field</th><th>map-release-versions</th><th>map-branch-versions</th>
  *     <th>map-development-versions</th>

--- a/maven-release-manager/src/main/java/org/apache/maven/shared/release/scm/ScmTranslator.java
+++ b/maven-release-manager/src/main/java/org/apache/maven/shared/release/scm/ScmTranslator.java
@@ -23,8 +23,8 @@ package org.apache.maven.shared.release.scm;
  * Translate the SCM information after tagging/reverting to trunk.
  *
  * @author <a href="mailto:brett@apache.org">Brett Porter</a>
- * @todo move this API into SCM?
  */
+// TODO move this API into SCM?
 public interface ScmTranslator
 {
     /**
@@ -58,7 +58,7 @@ public interface ScmTranslator
     /**
      * Translates an ScmFile path to a path relative to the working directory.
      *
-     * @param path
+     * @param path the ScmFile path
      * @return the relative path with OS specific File separator
      * @since 2.3.1
      */

--- a/maven-release-manager/src/main/java/org/apache/maven/shared/release/util/PomFinder.java
+++ b/maven-release-manager/src/main/java/org/apache/maven/shared/release/util/PomFinder.java
@@ -45,7 +45,7 @@ import org.codehaus.plexus.util.xml.pull.XmlPullParserException;
  * <h3>Usage:</h3>
  * <p>PomFinder is a statefull class. One instance of this class intended
  * for a singular use! You need to create a new instance if you like
- * to search for another pom.</p
+ * to search for another pom.</p>
  * <ol>
  *   <li>
  *     Parse an origin pom in a given directory with {@link #parsePom(java.io.File)}
@@ -98,9 +98,9 @@ public class PomFinder
     /**
      * Search for the previously with {@link #parsePom(java.io.File)}
      * parsed pom in the given directory.
-     * @param startDirectory
+     * @param startDirectory the initial directory
      * @return the pom file which matches the previously parsed pom or <code>null</code>
-     *         if no matching pom file could have been found.
+     * if no matching pom file could have been found.
      */
     public File findMatchingPom( File startDirectory )
     {

--- a/maven-release-manager/src/main/java/org/apache/maven/shared/release/versions/DefaultVersionInfo.java
+++ b/maven-release-manager/src/main/java/org/apache/maven/shared/release/versions/DefaultVersionInfo.java
@@ -33,27 +33,24 @@ import java.util.regex.Pattern;
 
 /**
  * This compares and increments versions for a common java versioning scheme.
- * <p/>
+ * <p>
  * The supported version scheme has the following parts.<br>
  * <code><i>component-digits-annotation-annotationRevision-buildSpecifier</i></code><br>
  * Example:<br>
  * <code>my-component-1.0.1-alpha-2-SNAPSHOT</code>
- * <p/>
- * <ul>Terms:
+ * <b>Terms:</b>
+ * <ul>
  * <li><i>component</i> - name of the versioned component (log4j, commons-lang, etc)
  * <li><i>digits</i> - Numeric digits with at least one "." period. (1.0, 1.1, 1.01, 1.2.3, etc)
  * <li><i>annotationRevision</i> - Integer qualifier for the annotation. (4 as in RC-4)
  * <li><i>buildSpecifier</i> - Additional specifier for build. (SNAPSHOT, or build number like "20041114.081234-2")
  * </ul>
  * <b>Digits is the only required piece of the version string, and must contain at lease one "." period.</b>
- * <p/>
  * Implementation details:<br>
  * The separators "_" and "-" between components are also optional (though they are usually recommended).<br>
  * Example:<br>
  * <code>log4j-1.2.9-beta-9-SNAPSHOT == log4j1.2.9beta9SNAPSHOT == log4j_1.2.9_beta_9_SNAPSHOT</code>
- * <p/>
  * Leading zeros are significant when performing comparisons.
- * <p/>
  * TODO: this parser is better than DefaultArtifactVersion - replace it with this (but align naming) and then remove
  * this from here.
  */
@@ -116,7 +113,8 @@ public class DefaultVersionInfo
     /**
      * Constructs this object and parses the supplied version string.
      *
-     * @param version
+     * @param version the version string
+     * @throws VersionParseException if an exception during parsing the input
      */
     public DefaultVersionInfo( String version )
         throws VersionParseException
@@ -274,7 +272,9 @@ public class DefaultVersionInfo
      * Takes a string and increments it as an integer.
      * Preserves any lpad of "0" zeros.
      *
-     * @param s
+     * @return {@code String} increments the input {@code String} as an integer 
+     * and Preserves any lpad of "0" zeros.
+     * @param s the version number
      */
     protected String incrementVersionString( String s )
     {
@@ -374,7 +374,8 @@ public class DefaultVersionInfo
     /**
      * Simply joins the items in the list with "." period
      *
-     * @param digits
+     * @return a single {@code String} of the items in the passed list, joined with a "."
+     * @param digits {@code List<String>} of digits
      */
     protected static String joinDigitString( List<String> digits )
     {

--- a/maven-release-plugin/src/main/java/org/apache/maven/plugins/release/PrepareReleaseMojo.java
+++ b/maven-release-plugin/src/main/java/org/apache/maven/plugins/release/PrepareReleaseMojo.java
@@ -44,8 +44,8 @@ import org.apache.maven.shared.release.config.ReleaseDescriptorBuilder;
  * @author <a href="mailto:jason@maven.org">Jason van Zyl</a>
  * @author <a href="mailto:brett@apache.org">Brett Porter</a>
  * @version $Id$
- * @todo [!] check how this works with version ranges
  */
+// TODO [!] check how this works with version ranges
 @Mojo( name = "prepare", aggregator = true, requiresDependencyCollection = ResolutionScope.TEST )
 public class PrepareReleaseMojo
     extends AbstractScmReleaseMojo

--- a/maven-release-plugin/src/test/java/org/apache/maven/plugins/release/stubs/FlatMultiModuleMavenProjectStub.java
+++ b/maven-release-plugin/src/test/java/org/apache/maven/plugins/release/stubs/FlatMultiModuleMavenProjectStub.java
@@ -34,6 +34,8 @@ import org.apache.maven.model.Scm;
  * Just overriding the ones I need for this plugin.
  *
  * @author <a href="mailto:oching@apache.org">Maria Odea Ching</a>
+ */
+/*
  * @noinspection ClassNameSameAsAncestorName
  */
 public class FlatMultiModuleMavenProjectStub


### PR DESCRIPTION
### Related JIRA Ticket
https://issues.apache.org/jira/browse/MRELEASE-1036

### What?
- Fix Javadocs

### Why?
- To be compatible with the JDK 8 doclint

# Testing:
✅`mvn javadoc:javadoc`
