### PR TITLE
(doc) Fix missing slash for closing tag in FAQs

### DIFF
--- a/maven-release-plugin/src/site/fml/faq.fml
+++ b/maven-release-plugin/src/site/fml/faq.fml
@@ -57,7 +57,7 @@ mvn -N -Darguments=-N release:perform
   <project>
    ...
     <properties>
-      <project.scm.id>my-scm-server<project.scm.id>
+      <project.scm.id>my-scm-server</project.scm.id>
     </properties>
   </project>
 ]]>


### PR DESCRIPTION
On the documentation website, the "project.scm.id" example in the "How can I hide my username and password?"
section is missing a slash for the closing tag.

This PR adds the slash.

See: https://maven.apache.org/maven-release/maven-release-plugin/faq.html#credentials