### PR TITLE
MRELEASE-1053 populate scm info from current module instead of execution root

### DIFF
--- a/maven-release-plugin/src/it/projects/prepare/MRELEASE-1053/module-a/pom.xml
+++ b/maven-release-plugin/src/it/projects/prepare/MRELEASE-1053/module-a/pom.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0"?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>org.apache.maven.plugin.release</groupId>
+    <artifactId>mrelease-1053-parent</artifactId>
+    <version>1.0-SNAPSHOT</version>
+    <relativePath>../module-parent/pom.xml</relativePath>
+  </parent>
+  <groupId>org.apache.maven.plugin.release</groupId>
+  <artifactId>module-a</artifactId>
+  <version>1.0-SNAPSHOT</version>
+  <dependencies>
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <version>3.8.1</version>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+</project>

--- a/maven-release-plugin/src/it/projects/prepare/MRELEASE-1053/module-a/src/main/java/org/apache/maven/plugin/release/module/a/App.java
+++ b/maven-release-plugin/src/it/projects/prepare/MRELEASE-1053/module-a/src/main/java/org/apache/maven/plugin/release/module/a/App.java
@@ -1,0 +1,32 @@
+package org.apache.maven.plugin.release.module.a;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * 
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/**
+ * Hello world!
+ *
+ */
+public class App 
+{
+    public static void main( String[] args )
+    {
+        System.out.println( "Hello World!" );
+    }
+}

--- a/maven-release-plugin/src/it/projects/prepare/MRELEASE-1053/module-a/src/test/java/org/apache/maven/plugin/release/module/a/AppTest.java
+++ b/maven-release-plugin/src/it/projects/prepare/MRELEASE-1053/module-a/src/test/java/org/apache/maven/plugin/release/module/a/AppTest.java
@@ -1,0 +1,57 @@
+package org.apache.maven.plugin.release.module.a;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * 
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import junit.framework.Test;
+import junit.framework.TestCase;
+import junit.framework.TestSuite;
+
+/**
+ * Unit test for simple App.
+ */
+public class AppTest 
+    extends TestCase
+{
+    /**
+     * Create the test case
+     *
+     * @param testName name of the test case
+     */
+    public AppTest( String testName )
+    {
+        super( testName );
+    }
+
+    /**
+     * @return the suite of tests being tested
+     */
+    public static Test suite()
+    {
+        return new TestSuite( AppTest.class );
+    }
+
+    /**
+     * Rigourous Test :-)
+     */
+    public void testApp()
+    {
+        assertTrue( true );
+    }
+}

--- a/maven-release-plugin/src/it/projects/prepare/MRELEASE-1053/module-parent/pom.xml
+++ b/maven-release-plugin/src/it/projects/prepare/MRELEASE-1053/module-parent/pom.xml
@@ -1,0 +1,59 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one
+  ~ or more contributor license agreements.  See the NOTICE file
+  ~ distributed with this work for additional information
+  ~ regarding copyright ownership.  The ASF licenses this file
+  ~ to you under the Apache License, Version 2.0 (the
+  ~ "License"); you may not use this file except in compliance
+  ~ with the License.  You may obtain a copy of the License at
+  ~
+  ~   http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied.  See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
+  -->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>org.apache.maven.plugin.release</groupId>
+  <artifactId>mrelease-1053-parent</artifactId>
+  <packaging>pom</packaging>
+  <version>1.0-SNAPSHOT</version>
+  
+  <scm>
+    <url>http://localhost/myscm/${project.scm.tag}</url>
+    <connection>scm:svn:file://localhost/${project.file.parentFile.parentFile}/target/svnroot/flat-multi-module/${project.scm.tag}/</connection>    
+    <developerConnection>scm:svn:file://localhost/${project.file.parentFile.parentFile}/target/svnroot/flat-multi-module/${project.scm.tag}/</developerConnection>
+    <tag>trunk</tag>
+  </scm>
+  
+  <properties>
+    <maven.compiler.source>@maven.compiler.source@</maven.compiler.source>
+    <maven.compiler.target>@maven.compiler.target@</maven.compiler.target>
+  </properties>
+
+  <build>
+    <pluginManagement>
+      <plugins>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-release-plugin</artifactId>
+          <version>@project.version@</version>
+        </plugin>
+      </plugins>
+    </pluginManagement>
+  </build>
+
+  <dependencies>
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <version>3.8.1</version>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+</project>

--- a/maven-release-plugin/src/it/projects/prepare/MRELEASE-1053/pom.xml
+++ b/maven-release-plugin/src/it/projects/prepare/MRELEASE-1053/pom.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one
+  ~ or more contributor license agreements.  See the NOTICE file
+  ~ distributed with this work for additional information
+  ~ regarding copyright ownership.  The ASF licenses this file
+  ~ to you under the Apache License, Version 2.0 (the
+  ~ "License"); you may not use this file except in compliance
+  ~ with the License.  You may obtain a copy of the License at
+  ~
+  ~   http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied.  See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
+  -->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>org.apache.maven.plugin.release</groupId>
+  <artifactId>mrelease-1053</artifactId>
+  <packaging>pom</packaging>
+  <version>1.0-SNAPSHOT</version>
+  <url>https://issues.apache.org/jira/browse/MRELEASE-1053</url>
+  <parent>
+    <groupId>org.apache.maven.plugin.release</groupId>
+    <artifactId>mrelease-1053-parent</artifactId>
+    <relativePath>module-parent/pom.xml</relativePath>
+    <version>1.0-SNAPSHOT</version>
+  </parent>
+  <modules>
+    <module>module-a</module>
+    <module>module-parent</module>
+  </modules>
+</project>

--- a/maven-release-plugin/src/it/projects/prepare/MRELEASE-1053/verify.groovy
+++ b/maven-release-plugin/src/it/projects/prepare/MRELEASE-1053/verify.groovy
@@ -1,0 +1,31 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+// check parent project
+def project = new XmlSlurper().parse( new File( new File ( basedir, 'module-parent' ), 'pom.xml.next' ) )
+assert project.version.text() == '1.1-SNAPSHOT'
+assert project.scm.url.text() == 'http://localhost/myscm/${project.scm.tag}'
+
+// check execution root project
+project = new XmlSlurper().parse( new File ( basedir, 'pom.xml.next' ) )
+assert 0 == project.scm.size() // scm element must not exist in reactor root
+
+// check module-a project
+project = new XmlSlurper().parse( new File( new File ( basedir, 'module-a' ), 'pom.xml.next' ) )
+assert 0 == project.scm.size() // scm element must not exist in module

--- a/maven-release-plugin/src/main/java/org/apache/maven/plugins/release/AbstractScmReleaseMojo.java
+++ b/maven-release-plugin/src/main/java/org/apache/maven/plugins/release/AbstractScmReleaseMojo.java
@@ -175,7 +175,7 @@ public abstract class AbstractScmReleaseMojo
                 String projectId =
                     ArtifactUtils.versionlessKey( reactorProject.getGroupId(), reactorProject.getArtifactId() );
                 
-                descriptor.addOriginalScmInfo( projectId, buildScm( project ) );
+                descriptor.addOriginalScmInfo( projectId, buildScm( reactorProject ) );
             }
         }
 


### PR DESCRIPTION
Following this checklist to help us incorporate your 
contribution quickly and easily:

 - [x] Make sure there is a [JIRA issue](https://issues.apache.org/jira/browse/MJAVADOC) filed 
       for the change (usually before you start working on it).  Trivial changes like typos do not 
       require a JIRA issue.  Your pull request should address just this issue, without 
       pulling in other changes.
 - [x] Each commit in the pull request should have a meaningful subject line and body.
 - [x] Format the pull request title like `[MJAVADOC-XXX] - Fixes bug in ApproximateQuantiles`,
       where you replace `MJAVADOC-XXX` with the appropriate JIRA issue. Best practice
       is to use the JIRA issue title in the pull request title and in the first line of the 
       commit message.
 - [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
 - [x] Run `mvn clean verify -Prun-its` to make sure basic checks pass. A more thorough check will 
       be performed on your pull request automatically.

If your pull request is about ~20 lines of code you don't need to sign an
[Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf) if you are unsure
please ask on the developers list.

To make clear that you license your contribution under 
the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
you have to acknowledge this by using the following check-box.

 - [x] I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)



This probably needs some unit/integration test, but I am not familiar enough with the code base to come up with some. The fix itself is trivial.