### PR TITLE
[MRELEASE-1066] fix XmlStreamReader not closed in unit test

### DIFF
--- a/maven-release-manager/src/test/java/org/apache/maven/shared/release/phase/AbstractBackupPomsPhaseTest.java
+++ b/maven-release-manager/src/test/java/org/apache/maven/shared/release/phase/AbstractBackupPomsPhaseTest.java
@@ -24,6 +24,7 @@ import org.apache.maven.model.io.xpp3.MavenXpp3Reader;
 import org.apache.maven.project.MavenProject;
 import org.apache.maven.shared.release.PlexusJUnit4TestCase;
 import org.codehaus.plexus.util.ReaderFactory;
+import org.codehaus.plexus.util.xml.XmlStreamReader;
 
 import java.io.File;
 import java.util.ArrayList;
@@ -79,15 +80,18 @@ public abstract class AbstractBackupPomsPhaseTest
     private MavenProject createMavenProject( File pomFile )
         throws Exception
     {
-        MavenXpp3Reader reader = new MavenXpp3Reader();
+        try (XmlStreamReader xmlReader = ReaderFactory.newXmlReader( pomFile ))
+        {
+            MavenXpp3Reader reader = new MavenXpp3Reader();
 
-        Model model = reader.read( ReaderFactory.newXmlReader( pomFile ) );
+            Model model = reader.read( xmlReader );
 
-        MavenProject project = new MavenProject( model );
+            MavenProject project = new MavenProject( model );
 
-        project.setFile( pomFile );
+            project.setFile( pomFile );
 
-        return project;
+            return project;
+        }
     }
 
 }


### PR DESCRIPTION
Steps to reproduce this issue on a Windows machine:
1. Checkout master (468520ac8d782d6c5a1419baa554a7ae3542038d)
2. Change the plex-utils version in the root pom's dependencyManagement (3.0.15 --> 3.3.0):
```
      <dependency>
        <groupId>org.codehaus.plexus</groupId>
        <artifactId>plexus-utils</artifactId>
        <version>3.3.0</version>
      </dependency>
```
3. Run the tests, these two tests will fail with the following message: "The process cannot access the file because it is being used by another process"
```
[ERROR]   RestoreBackupPomsPhaseTest.testBasicPom:63->runExecuteOnProjects:89 » ReleaseExecution
[ERROR]   RestoreBackupPomsPhaseTest.testMultiModulePom:79->runExecuteOnProjects:89 » ReleaseExecution
```

Original issue can be found on main maven jira: https://issues.apache.org/jira/browse/MRELEASE-1066



Following this checklist to help us incorporate your 
contribution quickly and easily:

 - [x] Make sure there is a [JIRA issue](https://issues.apache.org/jira/browse/MJAVADOC) filed 
       for the change (usually before you start working on it).  Trivial changes like typos do not 
       require a JIRA issue.  Your pull request should address just this issue, without 
       pulling in other changes.
 - [x] Each commit in the pull request should have a meaningful subject line and body.
 - [x] Format the pull request title like `[MJAVADOC-XXX] - Fixes bug in ApproximateQuantiles`,
       where you replace `MJAVADOC-XXX` with the appropriate JIRA issue. Best practice
       is to use the JIRA issue title in the pull request title and in the first line of the 
       commit message.
 - [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
 - [x] Run `mvn clean verify -Prun-its` to make sure basic checks pass. A more thorough check will 
       be performed on your pull request automatically.

If your pull request is about ~20 lines of code you don't need to sign an
[Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf) if you are unsure
please ask on the developers list.

To make clear that you license your contribution under 
the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
you have to acknowledge this by using the following check-box.

 - [x] I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)

 - [ ] In any other case, please file an [Apache Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).