### PR TITLE
Change interface implemented by MavenArtifactVersion

### DIFF
--- a/maven-release-api/src/main/java/org/apache/maven/shared/release/versions/MavenArtifactVersion.java
+++ b/maven-release-api/src/main/java/org/apache/maven/shared/release/versions/MavenArtifactVersion.java
@@ -23,7 +23,7 @@ import org.apache.maven.artifact.versioning.ArtifactVersion;
 import org.apache.maven.artifact.versioning.DefaultArtifactVersion;
 
 class MavenArtifactVersion
-    implements ArtifactVersion
+    implements Comparable<MavenArtifactVersion>
 {
     private final ArtifactVersion version;
 
@@ -32,71 +32,9 @@ class MavenArtifactVersion
         this.version = new DefaultArtifactVersion( version );
     }
 
-    public int compareTo( Object o )
+    public int compareTo( MavenArtifactVersion o )
     {
-        if ( o instanceof MavenArtifactVersion )
-        {
-            return version.compareTo( ( (MavenArtifactVersion) o ).version );
-        }
-        else
-        {
-            return version.compareTo( version );
-        }
-    }
-
-    /**
-     * <p>getMajorVersion.</p>
-     *
-     * @return a int
-     */
-    public int getMajorVersion()
-    {
-        return version.getMajorVersion();
-    }
-
-    /**
-     * <p>getMinorVersion.</p>
-     *
-     * @return a int
-     */
-    public int getMinorVersion()
-    {
-        return version.getMinorVersion();
-    }
-
-    /**
-     * <p>getIncrementalVersion.</p>
-     *
-     * @return a int
-     */
-    public int getIncrementalVersion()
-    {
-        return version.getIncrementalVersion();
-    }
-
-    /**
-     * <p>getBuildNumber.</p>
-     *
-     * @return a int
-     */
-    public int getBuildNumber()
-    {
-        return version.getBuildNumber();
-    }
-
-    /**
-     * <p>getQualifier.</p>
-     *
-     * @return a {@link java.lang.String} object
-     */
-    public String getQualifier()
-    {
-        return version.getQualifier();
-    }
-
-    public void parseVersion( String version )
-    {
-        this.version.parseVersion( version );
+        return version.compareTo( o.version );
     }
 
     @Override


### PR DESCRIPTION
Initially I planned to work on suspicious call
https://github.com/apache/maven-release/blob/d91b784796e93171171bbcd27c2dc7c97a186c82/maven-release-api/src/main/java/org/apache/maven/shared/release/versions/MavenArtifactVersion.java#L43
but after closer inspection this happened.