### PR TITLE
[MRELEASE-1077] Support for specifying profiles that can be activated during the prepare phase.

### DIFF
--- a/maven-release-plugin/src/it/projects/prepare/MRELEASE-1077/invoker.properties
+++ b/maven-release-plugin/src/it/projects/prepare/MRELEASE-1077/invoker.properties
@@ -1,0 +1,18 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+# 
+#   http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+invoker.goals = release:clean release:prepare

--- a/maven-release-plugin/src/it/projects/prepare/MRELEASE-1077/pom.xml
+++ b/maven-release-plugin/src/it/projects/prepare/MRELEASE-1077/pom.xml
@@ -1,0 +1,78 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one
+  ~ or more contributor license agreements.  See the NOTICE file
+  ~ distributed with this work for additional information
+  ~ regarding copyright ownership.  The ASF licenses this file
+  ~ to you under the Apache License, Version 2.0 (the
+  ~ "License"); you may not use this file except in compliance
+  ~ with the License.  You may obtain a copy of the License at
+  ~
+  ~   http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied.  See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
+  -->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>org.apache.maven.plugin.release.its</groupId>
+  <artifactId>mrelease-1077</artifactId>
+  <version>1.0-SNAPSHOT</version>
+  <scm>
+    <developerConnection>scm:dummy|nul</developerConnection>
+  </scm>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-release-plugin</artifactId>
+        <version>@project.version@</version>
+        <configuration>
+          <connectionUrl>scm:dummy|nul</connectionUrl>
+          <username>perform_username</username>
+          <password>perform_password</password>
+          <preparationProfiles>PrepProfA,PrepProfB</preparationProfiles>
+        </configuration>
+        <dependencies>
+          <dependency>
+            <groupId>org.apache.maven.its.release</groupId>
+            <artifactId>maven-scm-provider-dummy</artifactId>
+            <version>1.0</version>
+          </dependency>
+        </dependencies>
+      </plugin>
+
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-help-plugin</artifactId>
+        <version>3.3.0</version>
+        <executions>
+          <execution>
+            <id>Show profiles</id>
+            <phase>validate</phase>
+            <goals>
+              <goal>active-profiles</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+
+  <profiles>
+    <profile>
+      <id>PrepProfA</id>
+    </profile>
+
+    <profile>
+      <id>PrepProfB</id>
+    </profile>
+  </profiles>
+
+</project>

--- a/maven-release-plugin/src/it/projects/prepare/MRELEASE-1077/verify.groovy
+++ b/maven-release-plugin/src/it/projects/prepare/MRELEASE-1077/verify.groovy
@@ -1,0 +1,24 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+File buildLog = new File( basedir, 'build.log' )
+assert buildLog.exists()
+
+assert buildLog.text.contains( "[INFO]  - PrepProfA (source: org.apache.maven.plugin.release.its:mrelease-1077:1.0-SNAPSHOT)")
+assert buildLog.text.contains( "[INFO]  - PrepProfB (source: org.apache.maven.plugin.release.its:mrelease-1077:1.0-SNAPSHOT)")

--- a/maven-release-plugin/src/main/java/org/apache/maven/plugins/release/PrepareReleaseMojo.java
+++ b/maven-release-plugin/src/main/java/org/apache/maven/plugins/release/PrepareReleaseMojo.java
@@ -103,6 +103,12 @@ public class PrepareReleaseMojo extends AbstractScmReleaseMojo {
     private boolean addSchema;
 
     /**
+     * Comma separated profiles to enable on release prepare, in addition to active profiles for project execution.
+     */
+    @Parameter(property = "preparationProfiles")
+    private String preparationProfiles;
+
+    /**
      * Goals to run as part of the preparation step, after transformation but before committing. Space delimited.
      */
     @Parameter(defaultValue = "clean verify", property = "preparationGoals")
@@ -322,6 +328,14 @@ public class PrepareReleaseMojo extends AbstractScmReleaseMojo {
      */
     @Parameter(defaultValue = "false", property = "pinExternals")
     private boolean pinExternals;
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    protected String getAdditionalProfiles() {
+        return preparationProfiles;
+    }
 
     /**
      * Specifies the line separator to format pom.xml. The following properties are


### PR DESCRIPTION
In some of my projects I have the website for the project as part of the code base.
In those situations I want the website to show the latest released version of the project (I.e. not the current SNAPSHOT that is in the current code base).

To allow updating this version in my website automatically as part of the release process; I would like to have a way to activate the relevant plugins only during the prepare phase of the new release so that I can run the appropriate scripts to change the website.

The implementation is incredibly simple: I only had to attach the getAdditionalProfiles() for the PrepareReleaseMojo to a property. Most of the code is a new integration test.

Following this checklist to help us incorporate your 
contribution quickly and easily:

 - [x] Make sure there is a [JIRA issue](https://issues.apache.org/jira/browse/MRELEASE-1077) filed 
       for the change (usually before you start working on it).  Trivial changes like typos do not 
       require a JIRA issue.  Your pull request should address just this issue, without 
       pulling in other changes.
 - [X] Each commit in the pull request should have a meaningful subject line and body.
 - [X] Format the pull request title like `[MJAVADOC-XXX] - Fixes bug in ApproximateQuantiles`,
       where you replace `MJAVADOC-XXX` with the appropriate JIRA issue. Best practice
       is to use the JIRA issue title in the pull request title and in the first line of the 
       commit message.
 - [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
 - [x] Run `mvn clean verify -Prun-its` to make sure basic checks pass. A more thorough check will 
       be performed on your pull request automatically.

If your pull request is about ~20 lines of code you don't need to sign an
[Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf) if you are unsure
please ask on the developers list.

To make clear that you license your contribution under 
the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
you have to acknowledge this by using the following check-box.

 - [x] I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)

 - [x] In any other case, please file an [Apache Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).
   I'm already PMC for Apache Avro and comitter for Apache Flink

