### PR TITLE
Fix xsd NS

### DIFF
--- a/maven-release-manager/src/main/mdo/release-descriptor.mdo
+++ b/maven-release-manager/src/main/mdo/release-descriptor.mdo
@@ -18,8 +18,8 @@
   ~ under the License.
   -->
 
-<model xmlns="https://codehaus-plexus.github.io/MODELLO/1.4.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-       xsi:schemaLocation="https://codehaus-plexus.github.io/MODELLO/1.4.0 https://codehaus-plexus.github.io/modello/xsd/modello-1.4.0.xsd">
+<model xmlns="http://codehaus-plexus.github.io/MODELLO/1.4.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="http://codehaus-plexus.github.io/MODELLO/1.4.0 https://codehaus-plexus.github.io/modello/xsd/modello-1.4.0.xsd">
   <id>release-descriptor</id>
   <name>ReleaseDescriptor</name>
   <description>


### PR DESCRIPTION
```
$ wget https://codehaus-plexus.github.io/modello/xsd/modello-1.4.0.xsd
$ 
$ git checkout 48094bdb
$ xmlstarlet val -s modello-1.4.0.xsd -e maven-release-manager/src/main/mdo/release-descriptor.mdo
maven-release-manager/src/main/mdo/release-descriptor.mdo:22.140: Element '{https://codehaus-plexus.github.io/MODELLO/1.4.0}model': No matching global declaration available for the validation root.
maven-release-manager/src/main/mdo/release-descriptor.mdo - invalid
$ 
$ git checkout 0f4a5a8c
$ xmlstarlet val -s modello-1.4.0.xsd -e maven-release-manager/src/main/mdo/release-descriptor.mdo
maven-release-manager/src/main/mdo/release-descriptor.mdo - valid
```