### PR TITLE
Add git example for release:perform

### DIFF
--- a/maven-release-plugin/src/site/apt/examples/perform-release.apt.vm
+++ b/maven-release-plugin/src/site/apt/examples/perform-release.apt.vm
@@ -48,6 +48,12 @@ mvn release:perform
 mvn org.apache.maven.plugins:maven-release-plugin:${project.version}:perform -DconnectionUrl=scm:svn:https://svn.mycompany.com/repos/path/to/myproject/tags/myproject-1.2.3
 -------
 
+  If you are using git the tag is passed a little bit differently:
+
+-------
+mvn org.apache.maven.plugins:maven-release-plugin:${project.version}:perform -DconnectionUrl=scm:git:https://git.mycompany.com/repos/path/to/myproject -Dtag=myproject-1.2.3
+-------
+
   <<<release:perform>>> will fork a new Maven instance to build the checked-out project. This new Maven instance will use the
   same system configuration and Maven profiles used by the one running the <<<release:perform>>> goal. Since there's no pom.xml, 
   you should use the fully qualified name of the goal to ensure the right version of the maven-release-plugin is used.


### PR DESCRIPTION
Git doesn't support passing tags in the URL, however I have found that passing -Dtag does the trick.

This still will work only with 2.3.2 and earlier versions because of https://issues.apache.org/jira/browse/MRELEASE-839 , but at least nobody will have to spent 5 hours like me, trying to find why it doesn't work.

 - [X] I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)



