### PR TITLE
[MRELEASE-1082] configuration option for using a shallow clone

### DIFF
--- a/maven-release-api/src/main/java/org/apache/maven/shared/release/config/ReleaseDescriptor.java
+++ b/maven-release-api/src/main/java/org/apache/maven/shared/release/config/ReleaseDescriptor.java
@@ -285,6 +285,15 @@ public interface ReleaseDescriptor
     String getScmCommentPrefix();
 
     /**
+     * Get whether to use a shallow clone with no history or a full clone containing the full history during the
+     * release.
+     *
+     * @return boolean
+     * @since 3.0.0-M6
+     */
+    boolean isScmShallowClone();
+
+    /**
      * Get the SCM commit comment when setting pom.xml to release.
      *
      * @return String

--- a/maven-release-manager/src/main/java/org/apache/maven/shared/release/config/ReleaseDescriptorBuilder.java
+++ b/maven-release-manager/src/main/java/org/apache/maven/shared/release/config/ReleaseDescriptorBuilder.java
@@ -474,6 +474,19 @@ public class ReleaseDescriptorBuilder
     }
 
     /**
+     * <p>setScmShallowClone.</p>
+     *
+     * @param scmShallowClone a boolean
+     * @return a {@link org.apache.maven.shared.release.config.ReleaseDescriptorBuilder} object
+     * @since 3.0.0-M6
+     */
+    public ReleaseDescriptorBuilder setScmShallowClone( boolean scmShallowClone )
+    {
+        releaseDescriptor.setScmShallowClone( scmShallowClone );
+        return this;
+    }
+
+    /**
      * <p>setScmReleaseCommitComment.</p>
      *
      * @param scmReleaseCommitComment a {@link java.lang.String} object

--- a/maven-release-manager/src/main/java/org/apache/maven/shared/release/phase/CheckoutProjectFromScm.java
+++ b/maven-release-manager/src/main/java/org/apache/maven/shared/release/phase/CheckoutProjectFromScm.java
@@ -218,7 +218,8 @@ public class CheckoutProjectFromScm
         checkoutDirectory.mkdirs();
 
         CommandParameters commandParameters = new CommandParameters();
-        commandParameters.setString( CommandParameter.SHALLOW, Boolean.TRUE.toString() );
+        commandParameters.setString( CommandParameter.SHALLOW,
+                Boolean.valueOf( releaseDescriptor.isScmShallowClone() ).toString() );
 
         CheckOutScmResult scmResult = provider.checkOut( repository, new ScmFileSet( checkoutDirectory ),
                 new ScmTag( releaseDescriptor.getScmReleaseLabel() ), commandParameters );

--- a/maven-release-manager/src/main/mdo/release-descriptor.mdo
+++ b/maven-release-manager/src/main/mdo/release-descriptor.mdo
@@ -69,6 +69,16 @@
           </description>
         </field>
         <field>
+          <name>scmShallowClone</name>
+          <version>3.0.0+</version>
+          <type>boolean</type>
+          <defaultValue>true</defaultValue>
+          <description>
+            Get whether to use a shallow clone with no history or a full clone containing the full history during the
+            release
+          </description>
+        </field>
+        <field>
           <name>scmReleaseCommitComment</name>
           <version>3.0.0+</version>
           <type>String</type>

--- a/maven-release-manager/src/test/java/org/apache/maven/shared/release/phase/CheckoutProjectFromScmTest.java
+++ b/maven-release-manager/src/test/java/org/apache/maven/shared/release/phase/CheckoutProjectFromScmTest.java
@@ -22,7 +22,6 @@ package org.apache.maven.shared.release.phase;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.fail;
-import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
@@ -34,7 +33,7 @@ import java.io.File;
 import java.util.List;
 
 import org.apache.maven.project.MavenProject;
-import org.apache.maven.scm.CommandParameters;
+import org.apache.maven.scm.CommandParameter;
 import org.apache.maven.scm.ScmFileSet;
 import org.apache.maven.scm.ScmTag;
 import org.apache.maven.scm.command.checkout.CheckOutScmResult;
@@ -86,8 +85,8 @@ public class CheckoutProjectFromScmTest
         when( scmProviderMock.checkOut( eq( repository ),
                                         argThat( new IsScmFileSetEquals( new ScmFileSet( checkoutDirectory ) ) ),
                                         argThat( new IsScmTagEquals( new ScmTag( "release-label" ) ) ),
-                                        any( CommandParameters.class)))
-            .thenReturn( new CheckOutScmResult( "",null ) );
+                                        argThat( new HasCommandParameter( CommandParameter.SHALLOW, true ) ) ) )
+            .thenReturn( new CheckOutScmResult( "", null ) );
 
         ScmManagerStub stub = (ScmManagerStub) lookup( ScmManager.class );
         stub.setScmProvider( scmProviderMock );
@@ -106,7 +105,7 @@ public class CheckoutProjectFromScmTest
         verify( scmProviderMock ).checkOut( eq( repository ),
                                             argThat( new IsScmFileSetEquals( new ScmFileSet( checkoutDirectory ) ) ),
                                             argThat( new IsScmTagEquals( new ScmTag( "release-label" ) ) ),
-                                            any( CommandParameters.class ));
+                                            argThat( new HasCommandParameter( CommandParameter.SHALLOW, true ) ) );
         verifyNoMoreInteractions( scmProviderMock );
     }
 
@@ -129,7 +128,7 @@ public class CheckoutProjectFromScmTest
         when( scmProviderMock.checkOut( eq( repository ),
                                         argThat( new IsScmFileSetEquals( new ScmFileSet( checkoutDirectory ) ) ),
                                         argThat( new IsScmTagEquals( new ScmTag( "release-label" ) ) ),
-                                        any(CommandParameters.class)))
+                                        argThat( new HasCommandParameter( CommandParameter.SHALLOW, true ) ) ) )
             .thenReturn( new CheckOutScmResult( "", null ) );
 
         ScmManagerStub stub = (ScmManagerStub) lookup( ScmManager.class );
@@ -149,7 +148,7 @@ public class CheckoutProjectFromScmTest
         verify( scmProviderMock ).checkOut( eq( repository ),
                                             argThat( new IsScmFileSetEquals( new ScmFileSet( checkoutDirectory ) ) ),
                                             argThat( new IsScmTagEquals( new ScmTag( "release-label" ) ) ),
-                                            any( CommandParameters.class ));
+                                            argThat( new HasCommandParameter( CommandParameter.SHALLOW, true ) ) );
         verifyNoMoreInteractions( scmProviderMock );
     }
 
@@ -172,8 +171,8 @@ public class CheckoutProjectFromScmTest
         when( scmProviderMock.checkOut( eq( repository ),
                                         argThat( new IsScmFileSetEquals( new ScmFileSet( checkoutDirectory ) ) ),
                                         argThat( new IsScmTagEquals( new ScmTag( "release-label" ) ) ),
-                                        any( CommandParameters.class )) )
-            .thenReturn( new CheckOutScmResult( "",null ) );
+                                        argThat( new HasCommandParameter( CommandParameter.SHALLOW, true ) ) ) )
+            .thenReturn( new CheckOutScmResult( "", null ) );
 
         ScmManagerStub stub = (ScmManagerStub) lookup( ScmManager.class );
         stub.setScmProvider( scmProviderMock );
@@ -193,7 +192,7 @@ public class CheckoutProjectFromScmTest
         verify( scmProviderMock ).checkOut( eq( repository ),
                                             argThat( new IsScmFileSetEquals( new ScmFileSet( checkoutDirectory ) ) ),
                                             argThat( new IsScmTagEquals( new ScmTag( "release-label" ) ) ),
-                                            any( CommandParameters.class ));
+                                            argThat( new HasCommandParameter( CommandParameter.SHALLOW, true ) ) );
         verifyNoMoreInteractions( scmProviderMock );
     }
 

--- a/maven-release-manager/src/test/java/org/apache/maven/shared/release/phase/HasCommandParameter.java
+++ b/maven-release-manager/src/test/java/org/apache/maven/shared/release/phase/HasCommandParameter.java
@@ -1,0 +1,60 @@
+package org.apache.maven.shared.release.phase;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import org.apache.maven.scm.CommandParameter;
+import org.apache.maven.scm.CommandParameters;
+import org.apache.maven.scm.ScmException;
+import org.mockito.ArgumentMatcher;
+
+/**
+ * Mockito constraint to check if a command parameter has a specific value.
+ *
+ * @author <a href="mailto:michael@bigmichi1.de">Michael Cramer</a>
+ */
+public class HasCommandParameter implements ArgumentMatcher<CommandParameters>
+{
+    private final CommandParameter commandParameter;
+
+    private final Object expected;
+
+    public HasCommandParameter( CommandParameter commandParameter, Object expected )
+    {
+        this.commandParameter = commandParameter;
+        this.expected = expected;
+    }
+
+    @Override
+    public boolean matches( CommandParameters argument )
+    {
+        CommandParameters commandParameters = (CommandParameters) argument;
+
+        try
+        {
+            return commandParameters.getString( this.commandParameter ).equals( String.valueOf( expected ) );
+        }
+        catch ( ScmException e )
+        {
+            return false;
+        }
+    }
+
+
+}

--- a/maven-release-plugin/src/main/java/org/apache/maven/plugins/release/AbstractScmReleaseMojo.java
+++ b/maven-release-plugin/src/main/java/org/apache/maven/plugins/release/AbstractScmReleaseMojo.java
@@ -90,6 +90,12 @@ public abstract class AbstractScmReleaseMojo
     private String scmCommentPrefix;
 
     /**
+     * When cloning a repository if it should be a shallow clone or a full clone.
+     */
+    @Parameter( defaultValue = "true", property = "scmShallowClone" )
+    private boolean scmShallowClone = true;
+
+    /**
      * Implemented with git will or not push changes to the upstream repository.
      * <code>true</code> by default to preserve backward compatibility.
      * @since 2.1
@@ -149,6 +155,7 @@ public abstract class AbstractScmReleaseMojo
         descriptor.setScmTagBase( tagBase );
         descriptor.setScmUsername( username );
         descriptor.setScmCommentPrefix( scmCommentPrefix );
+        descriptor.setScmShallowClone( scmShallowClone );
 
         descriptor.setPushChanges( pushChanges );
         descriptor.setWorkItem( workItem );


### PR DESCRIPTION
Following this checklist to help us incorporate your 
contribution quickly and easily:

 - [x] Make sure there is a [JIRA issue](https://issues.apache.org/jira/browse/MJAVADOC) filed 
       for the change (usually before you start working on it).  Trivial changes like typos do not 
       require a JIRA issue.  Your pull request should address just this issue, without 
       pulling in other changes.
 - [x] Each commit in the pull request should have a meaningful subject line and body.
 - [x] Format the pull request title like `[MJAVADOC-XXX] - Fixes bug in ApproximateQuantiles`,
       where you replace `MJAVADOC-XXX` with the appropriate JIRA issue. Best practice
       is to use the JIRA issue title in the pull request title and in the first line of the 
       commit message.
 - [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
 - [x] Run `mvn clean verify -Prun-its` to make sure basic checks pass. A more thorough check will 
       be performed on your pull request automatically.

If your pull request is about ~20 lines of code you don't need to sign an
[Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf) if you are unsure
please ask on the developers list.

To make clear that you license your contribution under 
the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
you have to acknowledge this by using the following check-box.

 - [x] I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)

 - [ ] In any other case, please file an [Apache Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

This patch makes the shallow clone option configurable while still having the default of `true`. This is useful and needed when running for example a SonarQube analysis during the release process. When the option is `true` like the current hardcoded default the analyzer complains about missing blame information. If the full history is needed the option can now be set to `false` to get the full history.