### PR TITLE
[MRELEASE-839]: Unable to supply tag to release for release:perform

### DIFF
--- a/maven-release-plugin/src/it/projects/perform/MRELEASE-839/invoker.properties
+++ b/maven-release-plugin/src/it/projects/perform/MRELEASE-839/invoker.properties
@@ -1,0 +1,18 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+# 
+#   http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+invoker.goals = release:clean release:perform

--- a/maven-release-plugin/src/it/projects/perform/MRELEASE-839/pom.xml
+++ b/maven-release-plugin/src/it/projects/perform/MRELEASE-839/pom.xml
@@ -17,21 +17,28 @@
   ~ specific language governing permissions and limitations
   ~ under the License.
   -->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
 
-<project>
+  <groupId>org.apache.maven.plugin.release.its</groupId>
+  <artifactId>mrelease-832</artifactId>
+  <version>1.0-SNAPSHOT</version>
+
   <build>
     <plugins>
       <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-release-plugin</artifactId>
+        <version>@project.version@</version>
+        <dependencies>
+          <dependency>
+            <groupId>org.apache.maven.its.release</groupId>
+            <artifactId>maven-scm-provider-dummy</artifactId>
+            <version>1.0</version>
+          </dependency>
+        </dependencies>
         <configuration>
-          <settings implementation="org.apache.maven.settings.Settings"/>
-          <project implementation="org.apache.maven.plugins.release.stubs.MavenProjectStub"/>
-          <reactorProjects>
-            <reactorProject implementation="org.apache.maven.plugins.release.stubs.MavenProjectStub"/>
-          </reactorProjects>
-          <workingDirectory>${basedir}/target/checkout</workingDirectory>
-		  <goals>deploy site-deploy</goals>
-          <useReleaseProfile>true</useReleaseProfile>
+          <connectionUrl>scm:dummy|nul</connectionUrl>
           <tag>test-tag</tag>
         </configuration>
       </plugin>

--- a/maven-release-plugin/src/it/projects/perform/MRELEASE-839/verify.groovy
+++ b/maven-release-plugin/src/it/projects/perform/MRELEASE-839/verify.groovy
@@ -1,0 +1,24 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+File buildLog = new File( basedir, 'build.log' )
+assert buildLog.exists()
+
+assert buildLog.text.contains( "[DEBUG]   (f) tag = test-tag" )
+

--- a/maven-release-plugin/src/main/java/org/apache/maven/plugins/release/PerformReleaseMojo.java
+++ b/maven-release-plugin/src/main/java/org/apache/maven/plugins/release/PerformReleaseMojo.java
@@ -46,7 +46,7 @@ import org.codehaus.plexus.util.StringUtils;
  */
 @Mojo( name = "perform", aggregator = true, requiresProject = false )
 public class PerformReleaseMojo
-    extends AbstractReleaseMojo
+    extends AbstractScmReleaseMojo
 {
     /**
      * A space separated list of goals to execute on release perform. Default value is either <code>deploy</code> or

--- a/maven-release-plugin/src/test/java/org/apache/maven/plugins/release/PerformReleaseMojoTest.java
+++ b/maven-release-plugin/src/test/java/org/apache/maven/plugins/release/PerformReleaseMojoTest.java
@@ -54,6 +54,11 @@ public class PerformReleaseMojoTest
 {
     private File workingDirectory;
 
+    private static void assertTag(ArgumentCaptor<ReleasePerformRequest> argument) {
+        assertEquals( "test-tag", argument.getValue().getReleaseDescriptorBuilder().
+                build().getScmReleaseLabel() );
+    }
+
     public void testPerform()
         throws Exception
     {
@@ -67,7 +72,7 @@ public class PerformReleaseMojoTest
 
         ReleaseManager mock = mock( ReleaseManager.class );
         mojo.setReleaseManager( mock );
-        
+
         // execute
         mojo.execute();
         
@@ -78,6 +83,8 @@ public class PerformReleaseMojoTest
         assertNotNull( argument.getValue().getReleaseEnvironment()  );
         assertNotNull( argument.getValue().getReactorProjects() );
         assertEquals( Boolean.FALSE, argument.getValue().getDryRun() );
+        assertNotNull( argument.getValue().getReleaseDescriptorBuilder() );
+        assertTag( argument );
         verifyNoMoreInteractions( mock );
     }
 
@@ -85,6 +92,9 @@ public class PerformReleaseMojoTest
         throws Exception
     {
         PerformReleaseMojo mojo = getMojoWithProjectSite( "perform-with-flat-structure.xml" );
+
+        MavenProject project = (MavenProject) getVariableValueFromObject( mojo, "project" );
+        setVariableValueToObject( mojo, "session", newMavenSession( project ) );
 
         ReleaseDescriptorBuilder builder = createReleaseDescriptorBuilder( mojo );
         builder.setWorkingDirectory( workingDirectory.getAbsolutePath() );
@@ -106,6 +116,7 @@ public class PerformReleaseMojoTest
         assertNotNull( argument.getValue().getReleaseEnvironment()  );
         assertNotNull( argument.getValue().getReactorProjects() );
         assertEquals( Boolean.FALSE, argument.getValue().getDryRun() );
+        assertTag( argument );
         verifyNoMoreInteractions( mock );
     }
 
@@ -141,6 +152,7 @@ public class PerformReleaseMojoTest
         assertNotNull( argument.getValue().getReleaseEnvironment()  );
         assertNotNull( argument.getValue().getReactorProjects() );
         assertEquals( Boolean.FALSE, argument.getValue().getDryRun() );
+        assertTag( argument );
         verifyNoMoreInteractions( mock );
     }
 
@@ -195,6 +207,7 @@ public class PerformReleaseMojoTest
         assertNotNull( argument.getValue().getReleaseEnvironment()  );
         assertNotNull( argument.getValue().getReactorProjects() );
         assertEquals( Boolean.FALSE, argument.getValue().getDryRun() );
+        assertTag( argument );
 
         verifyNoMoreInteractions( mock );
     }
@@ -235,6 +248,7 @@ public class PerformReleaseMojoTest
         assertNotNull( argument.getValue().getReleaseEnvironment()  );
         assertNotNull( argument.getValue().getReactorProjects() );
         assertEquals( Boolean.FALSE, argument.getValue().getDryRun() );
+        assertTag( argument );
 
         verifyNoMoreInteractions( mock );
     }
@@ -264,6 +278,7 @@ public class PerformReleaseMojoTest
         assertNotNull( argument.getValue().getReleaseEnvironment()  );
         assertNotNull( argument.getValue().getReactorProjects() );
         assertEquals( Boolean.FALSE, argument.getValue().getDryRun() );
+        assertTag( argument );
 
         verifyNoMoreInteractions( mock );
     }
@@ -302,6 +317,7 @@ public class PerformReleaseMojoTest
         assertNotNull( argument.getValue().getReleaseEnvironment()  );
         assertNotNull( argument.getValue().getReactorProjects() );
         assertEquals( Boolean.FALSE, argument.getValue().getDryRun() );
+        assertTag( argument );
 
         verifyNoMoreInteractions( mock );
     }
@@ -340,6 +356,7 @@ public class PerformReleaseMojoTest
         assertNotNull( argument.getValue().getReleaseEnvironment()  );
         assertNotNull( argument.getValue().getReactorProjects() );
         assertEquals( Boolean.FALSE, argument.getValue().getDryRun() );
+        assertTag( argument );
 
         verifyNoMoreInteractions( mock );
     }
@@ -368,6 +385,7 @@ public class PerformReleaseMojoTest
         assertNotNull( argument.getValue().getReleaseEnvironment()  );
         assertNotNull( argument.getValue().getReactorProjects() );
         assertEquals( Boolean.FALSE, argument.getValue().getDryRun() );
+        assertTag( argument );
 
         verifyNoMoreInteractions( mock );
     }

--- a/maven-release-plugin/src/test/java/org/apache/maven/plugins/release/stubs/FlatMultiModuleMavenProjectStub.java
+++ b/maven-release-plugin/src/test/java/org/apache/maven/plugins/release/stubs/FlatMultiModuleMavenProjectStub.java
@@ -25,7 +25,6 @@ import java.util.List;
 
 import org.apache.maven.model.DistributionManagement;
 import org.apache.maven.model.Model;
-import org.apache.maven.model.Scm;
 
 /**
  * <p>Stub for a MavenProject with a flat structure.</p>
@@ -39,7 +38,7 @@ import org.apache.maven.model.Scm;
  * @noinspection ClassNameSameAsAncestorName
  */
 public class FlatMultiModuleMavenProjectStub
-    extends org.apache.maven.plugin.testing.stubs.MavenProjectStub
+    extends MavenProjectStub
 {   
     public void setDistributionManagement( DistributionManagement distributionManagement )
     {
@@ -75,14 +74,6 @@ public class FlatMultiModuleMavenProjectStub
     public File getBasedir()
     {
         return new File( "/flat-multi-module/root-project" ).getAbsoluteFile();
-    }
-    
-    public Scm getScm()
-    {
-        Scm scm = new Scm();
-        scm.setConnection( "scm:svn:file://localhost/target/svnroot/flat-multi-module/trunk/root-project" );
-        
-        return scm;
     }
     
     @Override

--- a/maven-release-plugin/src/test/java/org/apache/maven/plugins/release/stubs/MavenProjectStub.java
+++ b/maven-release-plugin/src/test/java/org/apache/maven/plugins/release/stubs/MavenProjectStub.java
@@ -21,6 +21,7 @@ package org.apache.maven.plugins.release.stubs;
 
 import org.apache.maven.model.DistributionManagement;
 import org.apache.maven.model.Model;
+import org.apache.maven.model.Scm;
 
 /**
  * <p>Stub for MavenProject.</p>
@@ -46,6 +47,26 @@ public class MavenProjectStub
             model = new Model();
             setModel( model );
         }
+        return model;
+    }
+
+    public Scm getScm()
+    {
+        Scm scm = new Scm();
+        scm.setConnection( "scm:svn:file://localhost/target/svnroot/flat-multi-module/trunk/root-project" );
+
+        return scm;
+    }
+
+    public Model getOriginalModel() {
+        Model model = super.getOriginalModel();
+
+        if (model == null) {
+            model = new Model();
+            model.setScm(getScm());
+            setOriginalModel(model);
+        }
+
         return model;
     }
 

--- a/maven-release-plugin/src/test/resources/mojos/perform/perform-with-args.xml
+++ b/maven-release-plugin/src/test/resources/mojos/perform/perform-with-args.xml
@@ -31,6 +31,7 @@
           </reactorProjects>
           <workingDirectory>${basedir}/target/checkout</workingDirectory>
           <useReleaseProfile>true</useReleaseProfile>
+          <tag>test-tag</tag>
 		  <goals>deploy site-deploy</goals>		  
           <arguments>-Dmaven.test.skip=true</arguments>
         </configuration>

--- a/maven-release-plugin/src/test/resources/mojos/perform/perform-with-flat-structure.xml
+++ b/maven-release-plugin/src/test/resources/mojos/perform/perform-with-flat-structure.xml
@@ -31,6 +31,7 @@
           </reactorProjects>
           <workingDirectory>${basedir}/target/checkout</workingDirectory>
           <useReleaseProfile>true</useReleaseProfile>
+          <tag>test-tag</tag>
           <connectionUrl>scm:svn:file://localhost/target/svnroot/flat-multi-module/trunk/root-project</connectionUrl>
           <goals>deploy</goals>
         </configuration>

--- a/maven-release-plugin/src/test/resources/mojos/perform/perform-with-multiline-goals.xml
+++ b/maven-release-plugin/src/test/resources/mojos/perform/perform-with-multiline-goals.xml
@@ -31,6 +31,7 @@
           </reactorProjects>
           <workingDirectory>${basedir}/target/checkout</workingDirectory>
           <useReleaseProfile>true</useReleaseProfile>
+          <tag>test-tag</tag>
  		  <goals>
 		     deploy
 			 site-deploy

--- a/maven-release-plugin/src/test/resources/mojos/perform/perform-with-scm.xml
+++ b/maven-release-plugin/src/test/resources/mojos/perform/perform-with-scm.xml
@@ -31,6 +31,7 @@
           </reactorProjects>
           <workingDirectory>${basedir}/target/checkout</workingDirectory>
           <useReleaseProfile>true</useReleaseProfile>
+          <tag>test-tag</tag>
           <connectionUrl>scm-url</connectionUrl>
  		  <goals>deploy site-deploy</goals>
         </configuration>

--- a/maven-release-plugin/src/test/resources/mojos/perform/perform-without-site.xml
+++ b/maven-release-plugin/src/test/resources/mojos/perform/perform-without-site.xml
@@ -32,6 +32,7 @@
           <workingDirectory>${basedir}/target/checkout</workingDirectory>
 		  <goals>deploy</goals>
           <useReleaseProfile>true</useReleaseProfile>
+          <tag>test-tag</tag>
         </configuration>
       </plugin>
     </plugins>


### PR DESCRIPTION
Following this checklist to help us incorporate your 
contribution quickly and easily:

 - [x] Make sure there is a [JIRA issue](https://issues.apache.org/jira/browse/MJAVADOC) filed 
       for the change (usually before you start working on it).  Trivial changes like typos do not 
       require a JIRA issue.  Your pull request should address just this issue, without 
       pulling in other changes.
 - [X] Each commit in the pull request should have a meaningful subject line and body.
 - [X] Format the pull request title like `[MJAVADOC-XXX] - Fixes bug in ApproximateQuantiles`,
       where you replace `MJAVADOC-XXX` with the appropriate JIRA issue. Best practice
       is to use the JIRA issue title in the pull request title and in the first line of the 
       commit message.
 - [X] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
 - [C] Run `mvn clean verify -Prun-its` to make sure basic checks pass. A more thorough check will 
       be performed on your pull request automatically.

If your pull request is about ~20 lines of code you don't need to sign an
[Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf) if you are unsure
please ask on the developers list.

To make clear that you license your contribution under 
the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
you have to acknowledge this by using the following check-box.

 - [X] I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)

 - [X] In any other case, please file an [Apache Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

This PR introduces a fix which allows a `tag` to be supplied either using a `-Dtag=<tag>` flag or passing the tag into the `<configuration><tag>tag</tag></configuration>` section of the release plugin in the pom. The `PerformReleasePojo` previously incorrectly extended `AbstractReleaseMojo` where it now extends `AbstractScmReleaseMojo`. This required some small changes to the unit tests where I updated the stub files to correct a NPE error and to also assert that the ScmReleaseLabel was being populated correctly. I also added a directory `MRELEASE-839` under it/projects/perform which contains the integration test for this issue.

From the Jira, the command to get the fixed changes is:
```bash
mvn org.apache.maven.plugins:maven-release-plugin:3.0.0-M7-SNAPSHOT:perform -DconnectionUrl=scm:git:https://gitlab.com/fake/r365-autoconfig.git -Dtag=0.1.14 -DuseReleaseProfile=false
```
Replacing the connectionUrl with correct SCM and required tag. I have tested that it works with both localCheckout set to true and false