### PR TITLE
[MRELEASE-1103] Wrong file path used for master pw file

### DIFF
--- a/maven-release-manager/src/main/java/org/apache/maven/shared/release/util/MavenCrypto.java
+++ b/maven-release-manager/src/main/java/org/apache/maven/shared/release/util/MavenCrypto.java
@@ -63,6 +63,9 @@ public class MavenCrypto {
     public MavenCrypto(DefaultSecDispatcher secDispatcher, PlexusCipher plexusCipher) {
         this.secDispatcher = secDispatcher;
         this.plexusCipher = plexusCipher;
+
+        // Adjust the default path (def path != maven path)
+        this.secDispatcher.setConfigurationFile("~/.m2/settings-security.xml");
     }
 
     public String decrypt(String value) throws MavenCryptoException {


### PR DESCRIPTION
Master pw path: Using plexus default, that is NOT same as Maven default.
Fix: we already inject DefaultPlexusSecDispatcher (not the iface), and it has setter, so use it.

---

https://issues.apache.org/jira/browse/MRELEASE-1103