### PR TITLE
[MRELEASE-851]: javaHome argument is now honored in InvokerMavenExecutor

### DIFF
--- a/maven-release-manager/src/main/java/org/apache/maven/shared/release/exec/ForkedMavenExecutor.java
+++ b/maven-release-manager/src/main/java/org/apache/maven/shared/release/exec/ForkedMavenExecutor.java
@@ -106,6 +106,10 @@ public class ForkedMavenExecutor extends AbstractMavenExecutor {
 
             cl.addEnvironment("MAVEN_TERMINATE_CMD", "on");
 
+            if (releaseEnvironment.getJavaHome() != null) {
+                cl.addEnvironment("JAVA_HOME", releaseEnvironment.getJavaHome().getAbsolutePath());
+            }
+
             if (settingsFile != null) {
                 cl.createArg().setValue("-s");
                 cl.createArg().setFile(settingsFile);

--- a/maven-release-manager/src/main/java/org/apache/maven/shared/release/exec/InvokerMavenExecutor.java
+++ b/maven-release-manager/src/main/java/org/apache/maven/shared/release/exec/InvokerMavenExecutor.java
@@ -76,6 +76,7 @@ public class InvokerMavenExecutor extends AbstractMavenExecutor {
                 // fix for MRELEASE-1105
                 // .addShellEnvironment( "MAVEN_DEBUG_OPTS", "" )
                 .setBatchMode(true)
+                .setJavaHome(releaseEnvironment.getJavaHome())
                 .setOutputHandler(getLogger()::info)
                 .setErrorHandler(getLogger()::error);
 

--- a/maven-release-plugin/src/main/java/org/apache/maven/plugins/release/AbstractReleaseMojo.java
+++ b/maven-release-plugin/src/main/java/org/apache/maven/plugins/release/AbstractReleaseMojo.java
@@ -91,7 +91,7 @@ public abstract class AbstractReleaseMojo extends AbstractMojo {
     private File mavenHome;
 
     /**
-     * The {@code JAVA_HOME} parameter to use for forked Maven invocations.
+     * The Java home parameter to use for forked Maven invocations.
      *
      * @since 2.0-beta-8
      */


### PR DESCRIPTION
I don't know why this bug does not get fixed. The documentation clearly says that you can use the argument `-DjavaHome=` to set the path to your jdk, but this parameter is not used anywhere in the code, thereby completely ignored. This is a huge pain for people who are using CI/CD servers (for example jenkins) with multiple jdks installed. In that case the release plugin is not usable.

So I adjusted the InvokerMavenExecutor so that it honors the `javaHome` argument.