### PR TITLE
fixup hamcrest dependencies

### DIFF
--- a/maven-release-manager/pom.xml
+++ b/maven-release-manager/pom.xml
@@ -163,7 +163,7 @@
     </dependency>
     <dependency>
       <groupId>org.hamcrest</groupId>
-      <artifactId>hamcrest-core</artifactId>
+      <artifactId>hamcrest</artifactId>
       <version>2.2</version>
       <scope>test</scope>
     </dependency>

--- a/maven-release-plugin/pom.xml
+++ b/maven-release-plugin/pom.xml
@@ -97,7 +97,7 @@
 
     <dependency>
       <groupId>org.hamcrest</groupId>
-      <artifactId>hamcrest-core</artifactId>
+      <artifactId>hamcrest</artifactId>
       <version>2.2</version>
       <scope>test</scope>
     </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -302,6 +302,11 @@
         <artifactId>xmlunit-core</artifactId>
         <version>2.9.1</version>
       </dependency>
+      <dependency>
+        <groupId>org.hamcrest</groupId>
+        <artifactId>hamcrest-core</artifactId>
+        <version>2.2</version>
+      </dependency>
     </dependencies>
   </dependencyManagement>
 


### PR DESCRIPTION
Cures dependency warnings but still selects the right version of hamcrest-core in transitive dependencies. See https://hamcrest.org/JavaHamcrest/distributables