### PR TITLE
Check all project parents for SCM information.

### DIFF
--- a/maven-release-manager/src/main/java/org/apache/maven/shared/release/phase/RewritePomsForReleasePhase.java
+++ b/maven-release-manager/src/main/java/org/apache/maven/shared/release/phase/RewritePomsForReleasePhase.java
@@ -28,7 +28,6 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Map;
 
-import org.apache.maven.artifact.ArtifactUtils;
 import org.apache.maven.model.Model;
 import org.apache.maven.model.Scm;
 import org.apache.maven.project.MavenProject;
@@ -81,24 +80,21 @@ public class RewritePomsForReleasePhase extends AbstractRewritePomsPhase {
                     throw new ReleaseExecutionException(e.getMessage(), e);
                 }
             } else {
-                MavenProject parent = project.getParent();
-                if (parent != null) {
-                    // If the SCM element is not present, only add it if the parent was not mapped (ie, it's external to
-                    // the release process and so has not been modified, so the values will not be correct on the tag),
-                    String parentId = ArtifactUtils.versionlessKey(parent.getGroupId(), parent.getArtifactId());
-                    if (!releaseDescriptor.hasOriginalScmInfo(parentId)) {
-                        // we need to add it, since it has changed from the inherited value
-                        Scm scmTarget = new Scm();
-                        // reset default value (HEAD)
-                        scmTarget.setTag(null);
+                // If the SCM element is not present, only add it if the parent was not mapped (ie, it's external to
+                // the release process and so has not been modified,
+                // so the values otherwise won't be correct on the tag),
+                if (ReleaseUtil.hasNoOriginalScmInfoInParents(project, releaseDescriptor)) {
+                    // we need to add it, since it has changed from the inherited value
+                    Scm scmTarget = new Scm();
+                    // reset default value (HEAD)
+                    scmTarget.setTag(null);
 
-                        try {
-                            if (translateScm(project, releaseDescriptor, scmTarget, scmRepository, result)) {
-                                modelTarget.setScm(scmTarget);
-                            }
-                        } catch (IOException e) {
-                            throw new ReleaseExecutionException(e.getMessage(), e);
+                    try {
+                        if (translateScm(project, releaseDescriptor, scmTarget, scmRepository, result)) {
+                            modelTarget.setScm(scmTarget);
                         }
+                    } catch (IOException e) {
+                        throw new ReleaseExecutionException(e.getMessage(), e);
                     }
                 }
             }

--- a/maven-release-manager/src/main/java/org/apache/maven/shared/release/util/ReleaseUtil.java
+++ b/maven-release-manager/src/main/java/org/apache/maven/shared/release/util/ReleaseUtil.java
@@ -26,6 +26,7 @@ import java.nio.file.Paths;
 import java.util.Arrays;
 import java.util.List;
 
+import org.apache.maven.artifact.ArtifactUtils;
 import org.apache.maven.model.Model;
 import org.apache.maven.project.MavenProject;
 import org.apache.maven.shared.release.ReleaseExecutionException;
@@ -203,5 +204,21 @@ public class ReleaseUtil {
             }
         }
         return value;
+    }
+
+    /**
+     * Check if none of the parent projects have original SCM info in the release descriptor.
+     */
+    public static boolean hasNoOriginalScmInfoInParents(MavenProject project, ReleaseDescriptor releaseDescriptor) {
+        MavenProject parent = project.getParent();
+        while (parent != null) {
+            String parentId = ArtifactUtils.versionlessKey(parent.getGroupId(), parent.getArtifactId());
+            if (releaseDescriptor.hasOriginalScmInfo(parentId)) {
+                return false;
+            }
+            parent = parent.getParent();
+        }
+
+        return true;
     }
 }

--- a/maven-release-plugin/src/it/projects/branch/gh-1420/module1/module2/pom.xml
+++ b/maven-release-plugin/src/it/projects/branch/gh-1420/module1/module2/pom.xml
@@ -1,0 +1,31 @@
+<?xml version='1.0'?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>org.codehaus.maven.plugins.release.its</groupId>
+    <artifactId>module1</artifactId>
+    <version>1.0-SNAPSHOT</version>
+  </parent>
+  <artifactId>module2</artifactId>
+  <packaging>pom</packaging>
+
+</project>

--- a/maven-release-plugin/src/it/projects/branch/gh-1420/module1/pom.xml
+++ b/maven-release-plugin/src/it/projects/branch/gh-1420/module1/pom.xml
@@ -1,0 +1,37 @@
+<?xml version='1.0'?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>org.codehaus.maven.plugins.release.its</groupId>
+    <artifactId>gh-1420</artifactId>
+    <version>1.0-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>module1</artifactId>
+
+  <packaging>pom</packaging>
+
+  <modules>
+    <module>module2</module>
+  </modules>
+
+</project>

--- a/maven-release-plugin/src/it/projects/branch/gh-1420/pom.xml
+++ b/maven-release-plugin/src/it/projects/branch/gh-1420/pom.xml
@@ -1,0 +1,50 @@
+<?xml version='1.0'?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>org.codehaus.maven.plugins.release.its</groupId>
+  <artifactId>gh-1420</artifactId>
+  <version>1.0-SNAPSHOT</version>
+  <packaging>pom</packaging>
+
+  <url>https://github.com/apache/maven-release/issues/1420</url>
+  <description>Check whether the child modules do not have an SCM tag</description>
+
+  <scm>
+    <connection>scm:git|sd_pa/tools/release-test</connection>
+    <tag>HEAD</tag>
+  </scm>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-release-plugin</artifactId>
+        <version>@project.version@</version>
+      </plugin>
+    </plugins>
+  </build>
+  
+  <modules>
+    <module>module1</module>
+  </modules>
+</project>

--- a/maven-release-plugin/src/it/projects/branch/gh-1420/verify.groovy
+++ b/maven-release-plugin/src/it/projects/branch/gh-1420/verify.groovy
@@ -1,0 +1,44 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import groovy.xml.XmlSlurper
+
+def pom = new XmlSlurper().parse( new File( basedir, 'pom.xml.branch' ) )
+assert pom.scm.tag.text() == 'gh-1420-1.0-SNAPSHOT'
+assert pom.version.text() == '1.0-SNAPSHOT'
+
+def pomNext = new XmlSlurper().parse( new File( basedir, 'pom.xml.next' ) )
+assert pomNext.scm.tag.text() == 'HEAD'
+assert pomNext.version.text() == '1.1-SNAPSHOT'
+
+def pom1 = new XmlSlurper().parse( new File( basedir, 'module1/pom.xml.branch' ) )
+assert pom1.scm.size() == 0
+assert pom1.parent.version.text() == '1.0-SNAPSHOT'
+
+def pom1Next = new XmlSlurper().parse( new File( basedir, 'module1/pom.xml.next' ) )
+assert pom1Next.scm.size() == 0
+assert pom1Next.parent.version.text() == '1.1-SNAPSHOT'
+
+def pom2 = new XmlSlurper().parse( new File( basedir, 'module1/module2/pom.xml.branch' ) )
+assert pom2.scm.size() == 0
+assert pom2.parent.version.text() == '1.0-SNAPSHOT'
+
+def pom2Next = new XmlSlurper().parse( new File( basedir, 'module1/module2/pom.xml.next' ) )
+assert pom2Next.scm.size() == 0
+assert pom2Next.parent.version.text() == '1.1-SNAPSHOT'

--- a/maven-release-plugin/src/it/projects/prepare/gh-1420/module1/module2/pom.xml
+++ b/maven-release-plugin/src/it/projects/prepare/gh-1420/module1/module2/pom.xml
@@ -1,0 +1,31 @@
+<?xml version='1.0'?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>org.codehaus.maven.plugins.release.its</groupId>
+    <artifactId>module1</artifactId>
+    <version>1.0-SNAPSHOT</version>
+  </parent>
+  <artifactId>module2</artifactId>
+  <packaging>pom</packaging>
+
+</project>

--- a/maven-release-plugin/src/it/projects/prepare/gh-1420/module1/pom.xml
+++ b/maven-release-plugin/src/it/projects/prepare/gh-1420/module1/pom.xml
@@ -1,0 +1,37 @@
+<?xml version='1.0'?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>org.codehaus.maven.plugins.release.its</groupId>
+    <artifactId>gh-1420</artifactId>
+    <version>1.0-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>module1</artifactId>
+
+  <packaging>pom</packaging>
+
+  <modules>
+    <module>module2</module>
+  </modules>
+
+</project>

--- a/maven-release-plugin/src/it/projects/prepare/gh-1420/pom.xml
+++ b/maven-release-plugin/src/it/projects/prepare/gh-1420/pom.xml
@@ -1,0 +1,50 @@
+<?xml version='1.0'?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>org.codehaus.maven.plugins.release.its</groupId>
+  <artifactId>gh-1420</artifactId>
+  <version>1.0-SNAPSHOT</version>
+  <packaging>pom</packaging>
+
+  <url>https://github.com/apache/maven-release/issues/1420</url>
+  <description>Check whether the child modules do not have an SCM tag</description>
+
+  <scm>
+    <connection>scm:git|sd_pa/tools/release-test</connection>
+    <tag>HEAD</tag>
+  </scm>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-release-plugin</artifactId>
+        <version>@project.version@</version>
+      </plugin>
+    </plugins>
+  </build>
+  
+  <modules>
+    <module>module1</module>
+  </modules>
+</project>

--- a/maven-release-plugin/src/it/projects/prepare/gh-1420/verify.groovy
+++ b/maven-release-plugin/src/it/projects/prepare/gh-1420/verify.groovy
@@ -1,0 +1,44 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import groovy.xml.XmlSlurper
+
+def pom = new XmlSlurper().parse( new File( basedir, 'pom.xml.tag' ) )
+assert pom.scm.tag.text() == 'gh-1420-1.0'
+assert pom.version.text() == '1.0'
+
+def pomNext = new XmlSlurper().parse( new File( basedir, 'pom.xml.next' ) )
+assert pomNext.scm.tag.text() == 'HEAD'
+assert pomNext.version.text() == '1.1-SNAPSHOT'
+
+def pom1 = new XmlSlurper().parse( new File( basedir, 'module1/pom.xml.tag' ) )
+assert pom1.scm.size() == 0
+assert pom1.parent.version.text() == '1.0'
+
+def pom1Next = new XmlSlurper().parse( new File( basedir, 'module1/pom.xml.next' ) )
+assert pom1Next.scm.size() == 0
+assert pom1Next.parent.version.text() == '1.1-SNAPSHOT'
+
+def pom2 = new XmlSlurper().parse( new File( basedir, 'module1/module2/pom.xml.tag' ) )
+assert pom2.scm.size() == 0
+assert pom2.parent.version.text() == '1.0'
+
+def pom2Next = new XmlSlurper().parse( new File( basedir, 'module1/module2/pom.xml.next' ) )
+assert pom2Next.scm.size() == 0
+assert pom2Next.parent.version.text() == '1.1-SNAPSHOT'


### PR DESCRIPTION
During the project transformation, we need to verify all parent projects. 
Otherwise, modules at deeper levels may have an SCM tag added unnecessarily.

fix #1420

