### PR TITLE
Document deprecation of ModelETL#getModel()

### DIFF
--- a/maven-release-manager/src/main/java/org/apache/maven/shared/release/transform/ModelETL.java
+++ b/maven-release-manager/src/main/java/org/apache/maven/shared/release/transform/ModelETL.java
@@ -51,11 +51,17 @@ public interface ModelETL {
      */
     void load(File pomFile) throws ReleaseExecutionException;
 
-    // will be removed once transform() is implemented
     /**
-     * <p>getModel.</p>
+     * Returns the intermediate {@link Model} representation.
      *
-     * @return a {@link org.apache.maven.model.Model} object
+     * @deprecated This method is a temporary accessor that exists only for
+     *             legacy workflow support. It will be removed once the
+     *             {@link #transform()} processing phase is fully implemented
+     *             and callers no longer need to access the intermediate model
+     *             directly.
+     *             There is no direct replacement. New code should rely on the
+     *             {@link #extract(File)} -> {@link #transform()} -> {@link #load(File)}
+     *             processing pipeline instead of accessing the model explicitly.
      */
     @Deprecated
     Model getModel();

--- a/maven-release-plugin/src/main/java/org/apache/maven/plugins/release/PerformReleaseMojo.java
+++ b/maven-release-plugin/src/main/java/org/apache/maven/plugins/release/PerformReleaseMojo.java
@@ -90,7 +90,6 @@ public class PerformReleaseMojo extends AbstractScmReadReleaseMojo {
      * artifact, if appropriate. If set to true, the release plugin sets the property "<code>performRelease</code>" to
      * true, which activates the profile "<code>release-profile</code>" as inherited from
      * <a href="/ref/3.8.5/maven-model-builder/super-pom.html">the super pom</a>.
-     *
      * @deprecated The <code>release-profile</code> profile will be removed from future versions of the super POM
      */
     @Parameter(defaultValue = "false", property = "useReleaseProfile")


### PR DESCRIPTION
Clarified that getModel() is a temporary legacy accessor and will be removed once transform() is fully implemented. Added guidance to rely on the extract -> transform -> load pipeline instead.

This work is part of Issue #1436 – Document Deprecations and improves the deprecation documentation for ModelETL#getModel().

- Confirmed this method is intentionally deprecated as a transitional API
- Added Javadoc explaining why it is deprecated and what to use instead
- No functional behavior changes
- Successfully verified build using `mvn clean install`

Reference: https://github.com/apache/maven-release/issues/1436

/cc @elharo

Following this checklist to help us incorporate your
contribution quickly and easily:

- [X] Your pull request should address just one issue, without pulling in other changes.
- [X] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [X] Each commit in the pull request should have a meaningful subject line and body.
  Note that commits might be squashed by a maintainer on merge.
- [ ] Write unit tests that match behavioral changes, where the tests fail if the changes to the runtime are not applied.
  This may not always be possible but is a best-practice.
- [X] Run `mvn verify` to make sure basic checks pass.
  A more thorough check will be performed on your pull request automatically.
- [ ] You have run the integration tests successfully (`mvn -Prun-its verify`).

If your pull request is about ~20 lines of code you don't need to sign an
[Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf) if you are unsure
please ask on the developers list.

To make clear that you license your contribution under
the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
you have to acknowledge this by using the following check-box.

- [X] I hereby declare this contribution to be licensed under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
- [ ] In any other case, please file an [Apache Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).
