### PR TITLE
Document deprecations in PrepareReleaseMojo and PerformReleaseMojo

### DIFF
--- a/maven-release-plugin/src/main/java/org/apache/maven/plugins/release/PerformReleaseMojo.java
+++ b/maven-release-plugin/src/main/java/org/apache/maven/plugins/release/PerformReleaseMojo.java
@@ -86,14 +86,17 @@ public class PerformReleaseMojo extends AbstractScmReadReleaseMojo {
     private boolean localCheckout;
 
     /**
-     * Whether to use the default release profile (Maven 2 and 3) that adds sources and javadocs to the released
-     * artifact, if appropriate. If set to true, the release plugin sets the property "<code>performRelease</code>" to
-     * true, which activates the profile "<code>release-profile</code>" as inherited from
-     * <a href="/ref/3.8.5/maven-model-builder/super-pom.html">the super pom</a>.
-     * @deprecated The <code>release-profile</code> profile will be removed from future versions of the super POM
+     * Whether to use the default {@code release-profile} from the Maven super POM,
+     * which adds sources and javadocs to the released artifacts when appropriate.
+     *
+     * @deprecated The {@code release-profile} is being removed from future versions
+     *             of the Maven super POM. Projects that require sources or javadocs
+     *             to be attached during a release should configure their own
+     *             explicit build or release profiles instead of relying on this
+     *             implicit profile.
      */
-    @Parameter(defaultValue = "false", property = "useReleaseProfile")
     @Deprecated
+    @Parameter(defaultValue = "false", property = "useReleaseProfile")
     private boolean useReleaseProfile;
 
     /**

--- a/maven-release-plugin/src/main/java/org/apache/maven/plugins/release/PrepareReleaseMojo.java
+++ b/maven-release-plugin/src/main/java/org/apache/maven/plugins/release/PrepareReleaseMojo.java
@@ -62,7 +62,10 @@ public class PrepareReleaseMojo extends AbstractScmReadWriteReleaseMojo {
     private boolean resume;
 
     /**
-     * @deprecated Please use release:prepare-with-pom instead.
+     * Controls whether the plugin should generate release POMs during the
+     * prepare phase.
+     *
+     * @deprecated Use the {@code release:prepare-with-pom} goal instead.
      */
     @Deprecated
     @Parameter(defaultValue = "false", property = "generateReleasePoms")


### PR DESCRIPTION
This PR is part of Issue #1436 – Document Deprecations and improves the
documentation of deprecated parameters in the Maven Release Plugin.

- Updated documentation for generateReleasePoms in PrepareReleaseMojo
  to explain why it is deprecated and recommend using
  release:prepare-with-pom instead.
- Updated documentation for useReleaseProfile in PerformReleaseMojo
  to clarify that the Maven super POM release-profile is being removed
  and projects should rely on explicit project-defined release profiles.
- No functional behavior changes.
- Build successfully verified using `mvn clean install`.

Reference: https://github.com/apache/maven-release/issues/1436  
/cc @elharo


Following this checklist to help us incorporate your
contribution quickly and easily:

- [x] Your pull request should address just one issue, without pulling in other changes.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Each commit in the pull request should have a meaningful subject line and body.
  Note that commits might be squashed by a maintainer on merge.
- [ ] Write unit tests that match behavioral changes, where the tests fail if the changes to the runtime are not applied.
  This may not always be possible but is a best-practice.
- [x] Run `mvn verify` to make sure basic checks pass.
  A more thorough check will be performed on your pull request automatically.
- [ ] You have run the integration tests successfully (`mvn -Prun-its verify`).

If your pull request is about ~20 lines of code you don't need to sign an
[Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf) if you are unsure
please ask on the developers list.

To make clear that you license your contribution under
the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
you have to acknowledge this by using the following check-box.

- [x] I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
- [ ] In any other case, please file an [Apache Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).
